### PR TITLE
Gemspec: Set the minitest version to less than < 5.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 Gemfile.lock
+*.swp
+*.swn
+*.swo

--- a/dynflow.gemspec
+++ b/dynflow.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport"
   s.add_dependency "multi_json"
   s.add_dependency "apipie-params"
-  s.add_development_dependency "minitest"
+
+  s.add_development_dependency "minitest", '~>4.7.5'
   s.add_development_dependency "sinatra"
 end


### PR DESCRIPTION
The test suite won't run with Minitest 5.0.0 currently so this prevents that version from being pulled in during bundle.
