### PR TITLE
Fix sequel migration

### DIFF
--- a/lib/dynflow/persistence_adapters/sequel_migrations/001_initial.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/001_initial.rb
@@ -18,8 +18,8 @@ Sequel.migration do
       foreign_key :execution_plan_uuid, :dynflow_execution_plans, type: String, size: 36, fixed: true
       index :execution_plan_uuid
       column :id, Fixnum
-      primary_key [:id, :execution_plan_uuid]
-      index [:id, :execution_plan_uuid], :unique => true
+      primary_key [:execution_plan_uuid, :id]
+      index [:execution_plan_uuid, :id], :unique => true
 
       column :data, String, text: true
     end
@@ -28,11 +28,11 @@ Sequel.migration do
       foreign_key :execution_plan_uuid, :dynflow_execution_plans, type: String, size: 36, fixed: true
       index :execution_plan_uuid
       column :id, Fixnum
-      primary_key [:id, :execution_plan_uuid]
-      index [:id, :execution_plan_uuid], :unique => true
+      primary_key [:execution_plan_uuid, :id]
+      index [:execution_plan_uuid, :id], :unique => true
       column :action_id, Fixnum
       foreign_key [:execution_plan_uuid, :action_id], :dynflow_actions
-      index [:action_id, :execution_plan_uuid], :unique => true
+      index [:execution_plan_uuid, :action_id], :unique => true
 
       column :data, String, text: true
 


### PR DESCRIPTION
Due to mixing order of the uuid and id on various places, there were
issues such as:

```
 DETAIL: Key columns "execution_plan_uuid" and "id" are of
 incompatible types: character and integer.
```

Basically, it tried to map the uuid to action id and vice-verse.
