### PR TITLE
Don't use the original exception for step#error

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -162,7 +162,7 @@ module Dynflow
       rescue => error
         action_logger.error error
         self.state = :error
-        @error     = error
+        @error     = ExecutionPlan::Steps::Error.new(error.class.name, error.message, error.backtrace)
       end
 
       case self.state

--- a/lib/dynflow/execution_plan/steps.rb
+++ b/lib/dynflow/execution_plan/steps.rb
@@ -1,6 +1,7 @@
 module Dynflow
   module ExecutionPlan::Steps
 
+    require 'dynflow/execution_plan/steps/error'
     require 'dynflow/execution_plan/steps/abstract'
     require 'dynflow/execution_plan/steps/abstract_flow_step'
     require 'dynflow/execution_plan/steps/plan_step'

--- a/lib/dynflow/execution_plan/steps/abstract.rb
+++ b/lib/dynflow/execution_plan/steps/abstract.rb
@@ -23,7 +23,7 @@ module Dynflow
         @id                = id || raise(ArgumentError, 'missing id')
         @execution_plan_id = is_kind_of! execution_plan_id, String
         @world             = is_kind_of! world, World
-        @error             = is_kind_of! error, Exception, NilClass
+        @error             = is_kind_of! error, ExecutionPlan::Steps::Error, NilClass
         @started_at        = is_kind_of! started_at, Time, NilClass
         @ended_at          = is_kind_of! ended_at, Time, NilClass
         @execution_time    = is_kind_of! execution_time, Float
@@ -73,9 +73,7 @@ module Dynflow
                           class:          self.class.to_s,
                           action_class:   action_class.to_s,
                           action_id:      action_id,
-                          error:          error ? { exception: error.class.name,
-                                                    message:   error.message,
-                                                    backtrace: error.backtrace } : nil,
+                          error:          error,
                           started_at:     time_to_str(started_at),
                           ended_at:       time_to_str(ended_at),
                           execution_time: execution_time,

--- a/lib/dynflow/execution_plan/steps/error.rb
+++ b/lib/dynflow/execution_plan/steps/error.rb
@@ -1,0 +1,26 @@
+module Dynflow
+  module ExecutionPlan::Steps
+    class Error < Serializable
+
+      attr_reader :exception, :message, :backtrace
+
+      def initialize(exception_class, message, backtrace)
+        @exception_class = exception_class
+        @message         = message
+        @backtrace       = backtrace
+      end
+
+      def self.new_from_hash(hash)
+        self.new(hash[:exception], hash[:message], hash[:backtrace])
+      end
+
+      def to_hash
+        { class:     self.class.name,
+          exception: exception,
+          message:   message,
+          backtrace: backtrace }
+      end
+
+    end
+  end
+end

--- a/lib/dynflow/serializable.rb
+++ b/lib/dynflow/serializable.rb
@@ -57,9 +57,7 @@ module Dynflow
 
     def self.hash_to_error(hash)
       return nil if hash.nil?
-      hash[:exception].constantize.new(hash[:message]).tap do |e|
-        e.set_backtrace hash[:backtrace]
-      end
+      ExecutionPlan::Steps::Error.from_hash(hash)
     end
 
     private_class_method :string_to_time, :hash_to_error


### PR DESCRIPTION
Use our own class instead. There were issues with
serializing/deserializing of the exceptions.
