### PR TITLE
Dummy action for renamed actions

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -9,6 +9,7 @@ module Dynflow
     extend Format
 
     require 'dynflow/action/suspended'
+    require 'dynflow/action/missing'
 
     require 'dynflow/action/plan_phase'
     require 'dynflow/action/flow_phase'
@@ -59,7 +60,7 @@ module Dynflow
     def self.from_hash(hash, phase, *args)
       check_class_key_present hash
       raise ArgumentError, "unknown phase '#{phase}'" unless [:plan_phase, :run_phase, :finalize_phase].include? phase
-      hash[:class].constantize.send(phase).new_from_hash(hash, *args)
+      Action.constantize(hash[:class]).send(phase).new_from_hash(hash, *args)
     end
 
     attr_reader :world, :state, :execution_plan_id, :id, :plan_step_id, :run_step_id, :finalize_step_id, :error
@@ -86,6 +87,12 @@ module Dynflow
       else
         self
       end
+    end
+
+    def self.constantize(action_name)
+      action_name.constantize
+    rescue NameError
+      Action::Missing.generate(action_name)
     end
 
     def action_logger

--- a/lib/dynflow/action/missing.rb
+++ b/lib/dynflow/action/missing.rb
@@ -1,0 +1,26 @@
+module Dynflow
+  # for cases the serialized action was renamed and it's not available
+  # in the code base anymore.
+  class Action::Missing < Dynflow::Action
+
+    def self.generate(action_name)
+      Class.new(self).tap do |klass|
+        klass.singleton_class.send(:define_method, :name) do
+          action_name
+        end
+      end
+    end
+
+    def plan(*args)
+      raise StandardError, "This action is not meant to be planned"
+    end
+
+    def run
+      raise StandardError, "This action is not meant to be run"
+    end
+
+    def finalize
+      raise StandardError, "This action is not meant to be finalized"
+    end
+  end
+end

--- a/lib/dynflow/execution_plan/steps/abstract.rb
+++ b/lib/dynflow/execution_plan/steps/abstract.rb
@@ -87,7 +87,7 @@ module Dynflow
         new execution_plan_id,
             hash[:id],
             hash[:state],
-            hash[:action_class].constantize,
+            Action.constantize(hash[:action_class]),
             hash[:action_id],
             hash_to_error(hash[:error]),
             world,

--- a/lib/dynflow/execution_plan/steps/plan_step.rb
+++ b/lib/dynflow/execution_plan/steps/plan_step.rb
@@ -57,7 +57,7 @@ module Dynflow
         new execution_plan_id,
             hash[:id],
             hash[:state],
-            hash[:action_class].constantize,
+            Action.constantize(hash[:action_class]),
             hash[:action_id],
             hash_to_error(hash[:error]),
             world,

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -2,27 +2,25 @@ require_relative 'test_helper'
 
 module Dynflow
 
-  #class ActionTest < Action
-  #
-  #  output_format do
-  #    param :id, String
-  #  end
-  #
-  #  def run
-  #    output['id'] = input['name']
-  #  end
-  #
-  #end
-  #
-  #describe 'running an action' do
-  #
-  #  it 'executed the run method storing results to output attribute'do
-  #    action = ActionTest.new('name' => 'zoo')
-  #    action.run
-  #    action.output.must_equal('id' => "zoo")
-  #  end
-  #
-  #end
+
+  describe Action::Missing do
+    include WorldInstance
+
+    let :action_data do
+      { class: 'RenamedAction',
+        state: 'success',
+        id: 123,
+        input: {},
+        execution_plan_id: 123 }
+    end
+
+    subject do
+      Action.from_hash(action_data, :run_phase, :success, world)
+    end
+
+    specify { subject.action_class.name.must_equal 'RenamedAction' }
+    specify { assert subject.is_a? Action }
+  end
 
 
   describe 'children' do


### PR DESCRIPTION
For use code, it happens that the action class is renamed, causing
issues when calling constantize on action that doesn't exist anymore.

This is expected only for action that were already finished. Therefore
we can replace it with a dummy one used only for read only purposes.
