### PR TITLE
Sequel settings cleanup

### DIFF
--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -1,4 +1,4 @@
-require 'sequel'
+require 'sequel/no_core_ext' # to avoid sequel ~> 3.0 coliding with ActiveRecord
 require 'multi_json'
 
 module Dynflow
@@ -89,7 +89,7 @@ module Dynflow
       end
 
       def migrate_db
-        ::Sequel::Migrator.apply(db, self.class.migrations_path)
+        ::Sequel::Migrator.run(db, self.class.migrations_path, table: 'dynflow_schema_info')
       end
 
       def save(what, condition, value)


### PR DESCRIPTION
Use explicit name for sequel schema table to avoid possible collisions
when multiple ORMs in place. Also avoid possible collisions with
ActiveRecord and Sequel 3.45.0 by explicitly not using sequel core extensions.

Dynflow with persistence was not officially release yet, if you happen to using it already, you need to reset the database or run this SQL command:

``` sql
insert into dynflow_schema_info (version) values ('1');
```
