### PR TITLE
Fix passing event objects with `to_a` method defined

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -383,7 +383,7 @@ module Dynflow
         save_state
         with_error_handling do
           result = catch(SUSPEND) do
-            world.middleware.execute(:run, self, *Array(event)) { |*args| run(*args) }
+            world.middleware.execute(:run, self, *[event].compact) { |*args| run(*args) }
           end
           if result == SUSPEND
             self.state = :suspended


### PR DESCRIPTION
When event object implemented a `to_a` method (for example Algebrick product),
it got expanded not to one event object, but to its array representation.
