### PR TITLE
Make sure the action children are stored only once

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -21,16 +21,18 @@ module Dynflow
     require 'dynflow/action/cancellable_polling'
 
     def self.all_children
-      children.inject(children) { |children, child| children + child.all_children }
+      children.values.inject(children.values) do |children, child|
+        children + child.all_children
+      end
     end
 
     def self.inherited(child)
-      children << child
+      children[child.name] = child
       super child
     end
 
     def self.children
-      @children ||= []
+      @children ||= {}
     end
 
     def self.middleware


### PR DESCRIPTION
This occurs with Rails reloading, where every reload causes the class to the
children array. Among other things, this might lead for subscribed action to
be added to the execution plan more times.
