### PR TITLE
DummyExecutionPlan.stub_planned_action

### DIFF
--- a/lib/dynflow/testing/dummy_execution_plan.rb
+++ b/lib/dynflow/testing/dummy_execution_plan.rb
@@ -7,14 +7,26 @@ module Dynflow
       attr_reader :id, :planned_plan_steps, :planned_run_steps, :planned_finalize_steps
 
       def initialize
-        @id                     = Testing.get_id.to_s
-        @planned_plan_steps     = []
-        @planned_run_steps      = []
-        @planned_finalize_steps = []
+        @id                       = Testing.get_id.to_s
+        @planned_plan_steps       = []
+        @planned_run_steps        = []
+        @planned_finalize_steps   = []
+        @planned_action_stubbers  = {}
       end
 
       def world
         @world ||= DummyWorld.new
+      end
+
+      # Allows modify the DummyPlannedAction returned by plan_action
+      def stub_planned_action(klass, &block)
+        @planned_action_stubbers[klass] = block
+      end
+
+      def add_plan_step(klass, _)
+        dummy_planned_action(klass).tap do |action|
+          @planned_plan_steps << action
+        end
       end
 
       def add_run_step(action)
@@ -27,9 +39,12 @@ module Dynflow
         action
       end
 
-      def add_plan_step(klass, action)
-        @planned_plan_steps << action = DummyPlannedAction.new(klass)
-        action
+      def dummy_planned_action(klass)
+        DummyPlannedAction.new(klass).tap do |action|
+          if planned_action_stubber = @planned_action_stubbers[klass]
+            planned_action_stubber.call(action)
+          end
+        end
       end
 
       def switch_flow(*args, &block)

--- a/test/testing_test.rb
+++ b/test/testing_test.rb
@@ -9,7 +9,7 @@ module Dynflow
 
     describe 'testing' do
 
-      it '#plan_action' do
+      specify '#plan_action' do
         input  = { 'input' => 'input' }
         action = create_and_plan_action CWE::DummyHeavyProgress, input
 
@@ -23,7 +23,17 @@ module Dynflow
         assert_action_planed action, CWE::DummySuspended
       end
 
-      it '#run_action without suspend' do
+      specify 'stub_plan_action' do
+        action = create_action CWE::DummyHeavyProgress
+        action.execution_plan.stub_planned_action(CWE::DummySuspended) do |sub_action|
+          sub_action.define_singleton_method(:test) { "test" }
+        end
+        plan_action(action, {})
+        stubbed_action = action.execution_plan.planned_plan_steps.first
+        stubbed_action.test.must_equal "test"
+      end
+
+      specify '#run_action without suspend' do
         input  = { 'input' => 'input' }
         plan   = create_and_plan_action CWE::DummyHeavyProgress, input
         action = run_action plan
@@ -37,7 +47,7 @@ module Dynflow
         action.progress_done.must_equal 1
       end
 
-      it '#run_action with suspend' do
+      specify '#run_action with suspend' do
         input  = { 'input' => 'input' }
         plan   = create_and_plan_action CWE::DummySuspended, input
         action = run_action plan
@@ -59,7 +69,7 @@ module Dynflow
         action.progress_done.must_equal 1
       end
 
-      it '#finalizes' do
+      specify '#finalize_action' do
         input                 = { 'input' => 'input' }
         plan                  = create_and_plan_action CWE::DummyHeavyProgress, input
         run                   = run_action plan
@@ -122,14 +132,14 @@ module Dynflow
         let(:planned_action) { create_and_plan_action CWE::Merge, plan_input }
         let(:runned_action) { run_action planned_action }
 
-        it '#plans' do
+        it 'plans' do
           assert_run_phase planned_action
           refute_finalize_phase planned_action
 
           planned_action.execution_plan.planned_plan_steps.must_be_empty
         end
 
-        it '#runs' do
+        it 'runs' do
           runned_action.output.fetch(:passed).must_equal true
         end
 
@@ -138,7 +148,7 @@ module Dynflow
             super.update review_results: [true, false]
           end
 
-          it '#runs' do
+          it 'runs' do
             runned_action.output.fetch(:passed).must_equal false
           end
         end


### PR DESCRIPTION
Sometimes, there is a need to simulate some behavior of sub action's plan
method. `DummyExecutionPlan.stub_planned_action` allows to register a block
that gets run when DummyPlannedAction is instanciated. This allows to extend
this dummy action to simulate the real behavior, to properly test the plan
method in isolation.

One of the examples might be something like:

``` ruby
def plan
sub_action = plan_action(SubAction, 123)
plan_action(AnotherSubAction, sub_action.input[:message]) end
```

Outside of testing, the sub_action.input gets filled by the SubAction#plan
method. However, since in tests we don't run the plan methods of sub actions,
we need another mechanism to simulate this.

Therefore, in tests, one can now do something like:

``` ruby
action = create_action(MyAction) 
action.execution_plan.stub_planned_action(SubAction) do |sub_action|
sub_action.stubs(input: { message: 123 }) end
```
