### PR TITLE
Change Type checks form Float to Numeric to work with BigDecimal

### DIFF
--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -48,8 +48,8 @@ module Dynflow
       @root_plan_step = root_plan_step
       @started_at     = Type! started_at, Time, NilClass
       @ended_at       = Type! ended_at, Time, NilClass
-      @execution_time = Type! execution_time, Float
-      @real_time      = Type! real_time, Float
+      @execution_time = Type! execution_time, Numeric
+      @real_time      = Type! real_time, Numeric
 
       steps.all? do |k, v|
         Type! k, Integer

--- a/lib/dynflow/execution_plan/steps/abstract.rb
+++ b/lib/dynflow/execution_plan/steps/abstract.rb
@@ -26,8 +26,8 @@ module Dynflow
         @error             = Type! error, ExecutionPlan::Steps::Error, NilClass
         @started_at        = Type! started_at, Time, NilClass
         @ended_at          = Type! ended_at, Time, NilClass
-        @execution_time    = Type! execution_time, Float
-        @real_time         = Type! real_time, Float
+        @execution_time    = Type! execution_time, Numeric
+        @real_time         = Type! real_time, Numeric
 
         self.state = state.to_sym
 


### PR DESCRIPTION
because `BigDecimal.superclass` is Numeric
