### PR TITLE
Enhanced polling action

### DIFF
--- a/lib/dynflow/action/polling.rb
+++ b/lib/dynflow/action/polling.rb
@@ -6,31 +6,23 @@ module Dynflow
     def run(event = nil)
       case event
       when nil
-        self.external_task = invoke_external_task
-        suspend_and_ping
+        if external_task
+          resume_external_action
+        else
+          initiate_external_action
+        end
       when Poll
-        self.external_task = poll_external_task
-        suspend_and_ping unless done?
+        poll_external_task_with_rescue
       else
         raise "unrecognized event #{event}"
       end
-    end
-
-    def external_task
-      raise NotImplementedError
     end
 
     def done?
       raise NotImplementedError
     end
 
-    private
-
     def invoke_external_task
-      raise NotImplementedError
-    end
-
-    def external_task=(external_task_data)
       raise NotImplementedError
     end
 
@@ -38,12 +30,80 @@ module Dynflow
       raise NotImplementedError
     end
 
+    # External task data. It should return nil when the task has not
+    # been triggered yet.
+    def external_task
+      output[:task]
+    end
+
+    def external_task=(external_task_data)
+      output[:task] = external_task_data
+    end
+
+    # What is the trend in waiting for next polling event. It allows
+    # to strart with frequent polling, but slow down once it's clear this
+    # task will take some time: the idea is we don't care that much in finishing
+    # few seconds sooner, when the task takes orders of minutes/hours. It allows
+    # not overwhelming the backend-servers with useless requests.
+    # By default, it switches to next interval after +attempts_before_next_interval+ number
+    # of attempts
+    def poll_intervals
+      [0.5, 1, 2, 4, 8, 16]
+    end
+
+    def attempts_before_next_interval
+      5
+    end
+
+    # Returns the time to wait between two polling intervals.
+    def poll_interval
+      interval_level = poll_attempts[:total]/attempts_before_next_interval
+      poll_intervals[interval_level] || poll_intervals.last
+    end
+
+    # How man times in row should we retry the polling before giving up
+    def poll_max_retries
+      3
+    end
+
+    def initiate_external_action
+      self.external_task = invoke_external_task
+      suspend_and_ping unless done?
+    end
+
+    def resume_external_action
+      poll_external_task_with_rescue
+    rescue
+      initiate_external_action
+    end
+
     def suspend_and_ping
       suspend { |suspended_action| world.clock.ping suspended_action, poll_interval, Poll }
     end
 
-    def poll_interval
-      0.5
+    def poll_external_task_with_rescue
+      poll_attempts[:total] += 1
+      self.external_task = poll_external_task
+      poll_attempts[:failed] = 0
+      suspend_and_ping unless done?
+    rescue => error
+      poll_attempts[:failed] += 1
+      rescue_poll_external_task(error)
     end
+
+    def poll_attempts
+      output[:poll_attempts] ||= { total: 0, failed: 0 }
+    end
+
+    def rescue_poll_external_task(error)
+      if poll_attempts[:failed] < poll_max_retries
+        action_logger.warn("Polling failed, attempt no. #{poll_attempts[:failed]}, retrying in #{poll_interval}")
+        action_logger.warn(error)
+        suspend_and_ping
+      else
+        raise error
+      end
+    end
+
   end
 end

--- a/lib/dynflow/testing.rb
+++ b/lib/dynflow/testing.rb
@@ -3,7 +3,7 @@ module Dynflow
     extend Algebrick::TypeCheck
 
     def self.logger_adapter
-      @logger_adapter ||= LoggerAdapters::Simple.new $stdout, 0
+      @logger_adapter || LoggerAdapters::Simple.new($stdout, 1)
     end
 
     def self.logger_adapter=(adapter)

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -91,5 +91,166 @@ module Dynflow
       end
     end
 
+    describe 'polling action' do
+      CWE = Support::CodeWorkflowExample
+      include Dynflow::Testing
+
+      class ExternalService
+        def invoke(args)
+          reset!
+        end
+
+        def poll(id)
+          raise 'fail' if @current_state[:failing]
+          @current_state[:progress] += 10
+          return @current_state
+        end
+
+        def reset!
+          @current_state = { task_id: 123, progress: 0 }
+        end
+
+        def will_fail
+          @current_state[:failing] = true
+        end
+
+        def wont_fail
+          @current_state.delete(:failing)
+        end
+      end
+
+      class TestPollingAction < Dynflow::Action
+
+        class Config
+          attr_accessor :external_service, :poll_max_retries,
+              :poll_intervals, :attempts_before_next_interval
+
+          def initialize
+            @external_service              = ExternalService.new
+            @poll_max_retries              = 2
+            @poll_intervals                = [0.5, 1]
+            @attempts_before_next_interval = 2
+          end
+        end
+
+        include Dynflow::Action::Polling
+
+        def invoke_external_task
+          external_service.invoke(input[:task_args])
+        end
+
+        def poll_external_task
+          external_service.poll(external_task[:task_id])
+        end
+
+        def done?
+          external_task && external_task[:progress] >= 100
+        end
+
+        def poll_max_retries
+          self.class.config.poll_max_retries
+        end
+
+        def poll_intervals
+          self.class.config.poll_intervals
+        end
+
+        def attempts_before_next_interval
+          self.class.config.attempts_before_next_interval
+        end
+
+        class << self
+          def config
+            @config ||= Config.new
+          end
+
+          attr_writer :config
+        end
+
+        def external_service
+          self.class.config.external_service
+        end
+      end
+
+      let(:plan) do
+        create_and_plan_action TestPollingAction, { task_args: 'do something' }
+      end
+
+      before do
+        TestPollingAction.config = TestPollingAction::Config.new
+      end
+
+      def next_ping(action)
+        action.world.clock.pending_pings.first
+      end
+
+      it 'initiates the external task' do
+        action   = run_action plan
+
+        action.output[:task][:task_id].must_equal 123
+      end
+
+      it 'polls till the task is done' do
+        action   = run_action plan
+
+        9.times { progress_action_time action }
+        action.done?.must_equal false
+        next_ping(action).wont_be_nil
+        action.state.must_equal :suspended
+
+        progress_action_time action
+        action.done?.must_equal true
+        next_ping(action).must_be_nil
+        action.state.must_equal :success
+      end
+
+      it 'tries to poll for the old task when resuming' do
+        action   = run_action plan
+        action.output[:task][:progress].must_equal 0
+        run_action action
+        action.output[:task][:progress].must_equal 10
+      end
+
+      it 'invokes the external task again when polling on the old one fails' do
+        action   = run_action plan
+        action.world.action_logger.level = 3
+        action.external_service.will_fail
+        action.output[:task][:progress].must_equal 0
+        run_action action
+        action.output[:task][:progress].must_equal 0
+      end
+
+      it 'tolerates some failure while polling' do
+        action   = run_action plan
+        action.external_service.will_fail
+        action.world.action_logger.level = 4
+
+        TestPollingAction.config.poll_max_retries = 3
+        (1..2).each do |attempt|
+          progress_action_time action
+          action.poll_attempts[:failed].must_equal attempt
+          next_ping(action).wont_be_nil
+          action.state.must_equal :suspended
+        end
+
+        progress_action_time action
+        action.poll_attempts[:failed].must_equal 3
+        next_ping(action).must_be_nil
+        action.state.must_equal :error
+      end
+
+      it 'allows increasing poll interval in a time' do
+        TestPollingAction.config.poll_intervals = [1, 2]
+        TestPollingAction.config.attempts_before_next_interval = 1
+
+        action   = run_action plan
+        next_ping(action).when.must_equal 1
+        progress_action_time action
+        next_ping(action).when.must_equal 2
+        progress_action_time action
+        next_ping(action).when.must_equal 2
+      end
+
+    end
   end
 end

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -203,8 +203,8 @@ module Dynflow
                   result.result.must_equal :success
                   result.state.must_equal :stopped
                   action = world.persistence.load_action result.steps[2]
-                  action.output[:progress].must_equal 30
-                  action.output[:cancelled].must_equal true
+                  action.output[:task][:progress].must_equal 30
+                  action.output[:task][:cancelled].must_equal true
                 end
               end
 
@@ -219,7 +219,7 @@ module Dynflow
                   step = result.steps[2]
                   step.error.message.must_equal 'action cancelled'
                   action = world.persistence.load_action step
-                  action.output[:progress].must_equal 30
+                  action.output[:task][:progress].must_equal 30
                 end
               end
 
@@ -241,8 +241,8 @@ module Dynflow
                     result.result.must_equal :success
                     result.state.must_equal :stopped
                     action = world.persistence.load_action result.steps[2]
-                    action.output[:progress].must_be :<=, 30
-                    action.output[:cancelled].must_equal true
+                    action.output[:task][:progress].must_be :<=, 30
+                    action.output[:task][:cancelled].must_equal true
                   end
                 end
               end

--- a/test/support/code_workflow_example.rb
+++ b/test/support/code_workflow_example.rb
@@ -290,22 +290,14 @@ module Support
 
       def cancel_external_task
         if input[:text] !~ /cancel-fail/
-          { cancelled: true }
+          external_task.merge(cancelled: true)
         else
           error! 'action cancelled'
         end
       end
 
-      def external_task=(external_task_data)
-        self.output.update external_task_data
-      end
-
-      def external_task
-        output
-      end
-
       def done?
-        external_task[:progress] >= 100
+        external_task && external_task[:progress] >= 100
       end
 
       def poll_interval
@@ -313,7 +305,7 @@ module Support
       end
 
       def run_progress
-        output[:progress].to_f / 100
+        external_task && external_task[:progress].to_f / 100
       end
     end
 
@@ -325,14 +317,6 @@ module Support
         { progress: 0, done: false }
       end
 
-      def external_task=(external_task_data)
-        self.output.update external_task_data
-      end
-
-      def external_task
-        output
-      end
-
       def poll_external_task
         if input[:text] == 'troll progress' && !output[:trolled]
           output[:trolled] = true
@@ -340,15 +324,15 @@ module Support
         end
 
         if input[:text] =~ /pause in progress (\d+)/
-          TestPause.pause if output[:progress] == $1.to_i
+          TestPause.pause if external_task[:progress] == $1.to_i
         end
 
-        progress = output[:progress] + 10
+        progress = external_task[:progress] + 10
         { progress: progress, done: progress >= 100 }
       end
 
       def done?
-        external_task[:progress] >= 100
+        external_task && external_task[:progress] >= 100
       end
 
       def poll_interval
@@ -356,7 +340,7 @@ module Support
       end
 
       def run_progress
-        output[:progress].to_f / 100
+        external_task && external_task[:progress].to_f / 100
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,8 +17,6 @@ require 'pry'
 require 'support/code_workflow_example'
 require 'support/middleware_example'
 
-Dynflow::Testing.logger_adapter.level = 1
-
 class TestExecutionLog
 
   include Enumerable

--- a/test/testing_test.rb
+++ b/test/testing_test.rb
@@ -53,20 +53,24 @@ module Dynflow
         plan   = create_and_plan_action CWE::DummySuspended, input
         action = run_action plan
 
-        action.output.must_equal 'progress' => 0, 'done' => false
+        action.output.must_equal 'task' => { 'progress' => 0, 'done' => false }
         action.progress_done.must_equal 0
 
         3.times { progress_action_time action }
-        action.output.must_equal 'progress' => 30, 'done' => false
+        action.output.must_equal('task' => { 'progress' => 30, 'done' => false } ,
+                                 'poll_attempts' => {'total' => 2, 'failed'=> 0 })
         action.progress_done.must_equal 0.3
 
         run_action action, Dynflow::Action::Polling::Poll
         run_action action, Dynflow::Action::Polling::Poll
-        action.output.must_equal 'progress' => 50, 'done' => false
+        action.output.must_equal('task' => { 'progress' => 50, 'done' => false },
+                                 'poll_attempts' => {'total' => 4, 'failed' => 0 })
         action.progress_done.must_equal 0.5
 
         5.times { progress_action_time action }
-        action.output.must_equal 'progress' => 100, 'done' => true
+
+        action.output.must_equal('task' => { 'progress' => 100, 'done' => true },
+                                 'poll_attempts' => {'total' => 9, 'failed' => 0 })
         action.progress_done.must_equal 1
       end
 


### PR DESCRIPTION
- when resuming, tries first the previous task if present
- when error occurs while polling, retries several times before
  actually failing
- it allows to start with short polling intervals and increase that
  later
- less methods needed to define to actually start using it

For better testing, I've also made the testing logger non-singleton by
default, so that one can set log levels per test. Also, it's possible better
inspect the managed clocks now.
