### PR TITLE
We don't need to save execution plan to update execution time

### DIFF
--- a/lib/dynflow/execution_plan/steps/plan_step.rb
+++ b/lib/dynflow/execution_plan/steps/plan_step.rb
@@ -54,8 +54,6 @@ module Dynflow
           action.execute(*args)
         end
 
-        execution_plan.update_execution_time execution_time
-
         persistence.save_action(execution_plan_id, action)
         return action
       end

--- a/lib/dynflow/executors/parallel/execution_plan_manager.rb
+++ b/lib/dynflow/executors/parallel/execution_plan_manager.rb
@@ -51,15 +51,8 @@ module Dynflow
                    execution_plan.steps[step.id] = step
                    suspended, work = @running_steps_manager.done(step)
                    unless suspended
-                     execution_plan.update_execution_time step.execution_time
                      work = compute_next_from_step.call step
                    end
-                   # TODO: can be probably disabled to improve
-                   # performance, execution time will not be updated,
-                   # maybe more - check on the other side, it allows
-                   # us to use persistence adapter for hooking into
-                   # the running process.
-                   execution_plan.save
                    work
                  end),
                 (on Work::Finalize do

--- a/lib/dynflow/executors/parallel/sequential_manager.rb
+++ b/lib/dynflow/executors/parallel/sequential_manager.rb
@@ -70,8 +70,6 @@ module Dynflow
 
       def run_step(step)
         step.execute
-        execution_plan.update_execution_time step.execution_time
-        execution_plan.save
         return step.state != :error
       end
 


### PR DESCRIPTION
This should enhance performance by 30% (depending on the complexity of 
execution plan).
