### PR TITLE
Save root action before planning starts

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -100,9 +100,7 @@ module Dynflow
       @run_step_id       = Type! attributes.fetch(:run_step_id), Integer, NilClass
       @finalize_step_id  = Type! attributes.fetch(:finalize_step_id), Integer, NilClass
 
-      @execution_plan    = Type!(attributes.fetch(:execution_plan),
-                                 ExecutionPlan) if phase? Plan, Present
-      @trigger           = Type! attributes.fetch(:trigger), Action, NilClass if phase? Plan
+      @execution_plan    = Type!(attributes.fetch(:execution_plan), ExecutionPlan) if phase? Present
 
       getter =-> key, required do
         required ? attributes.fetch(key) : attributes.fetch(key, {})
@@ -140,6 +138,12 @@ module Dynflow
       else
         @output
       end
+    end
+
+    def set_plan_context(execution_plan, trigger)
+      phase! Plan
+      @execution_plan = Type! execution_plan, ExecutionPlan
+      @trigger        = Type! trigger, Action, NilClass
     end
 
     def trigger

--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -143,7 +143,8 @@ module Dynflow
 
     def prepare(action_class)
       save
-      @root_plan_step = add_step(Steps::PlanStep, action_class, generate_action_id)
+      @root_plan_step = add_plan_step(action_class)
+      @root_plan_step.save
     end
 
     def plan(*args)
@@ -225,8 +226,10 @@ module Dynflow
       current_run_flow.add_and_resolve(@dependency_graph, new_flow) if current_run_flow
     end
 
-    def add_plan_step(action_class, planned_by)
-      add_step(Steps::PlanStep, action_class, generate_action_id, planned_by.plan_step_id)
+    def add_plan_step(action_class, planned_by = nil)
+      add_step(Steps::PlanStep, action_class, generate_action_id, planned_by && planned_by.plan_step_id).tap do |step|
+        step.initialize_action
+      end
     end
 
     def add_run_step(action)

--- a/lib/dynflow/testing/factories.rb
+++ b/lib/dynflow/testing/factories.rb
@@ -9,15 +9,15 @@ module Dynflow
         step           = DummyStep.new
         action_class.new(
             { step:              DummyStep.new,
-              execution_plan:    execution_plan,
-              trigger:           trigger,
               execution_plan_id: execution_plan.id,
               id:                Testing.get_id,
               phase:             Action::Plan,
               plan_step_id:      step.id,
               run_step_id:       nil,
               finalize_step_id:  nil },
-            execution_plan.world)
+            execution_plan.world).tap do |action|
+          action.set_plan_context(execution_plan, trigger)
+        end
       end
 
       def create_action_presentation(action_class)


### PR DESCRIPTION
We need this to be able to get the data about the action that triggered the
execution plan before the planning is finished.
