### PR TITLE
Ensure deserialization from json keeps numeric values

### DIFF
--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -279,8 +279,8 @@ module Dynflow
                steps,
                string_to_time(hash[:started_at]),
                string_to_time(hash[:ended_at]),
-               hash[:execution_time],
-               hash[:real_time])
+               hash[:execution_time].to_f,
+               hash[:real_time].to_f)
     end
 
     def compute_execution_time

--- a/lib/dynflow/execution_plan/steps/abstract.rb
+++ b/lib/dynflow/execution_plan/steps/abstract.rb
@@ -138,10 +138,10 @@ module Dynflow
             world,
             string_to_time(hash[:started_at]),
             string_to_time(hash[:ended_at]),
-            hash[:execution_time],
-            hash[:real_time],
-            hash[:progress_done],
-            hash[:progress_weight]
+            hash[:execution_time].to_f,
+            hash[:real_time].to_f,
+            hash[:progress_done].to_f,
+            hash[:progress_weight].to_f
       end
 
       private


### PR DESCRIPTION
After Oj 2.10.0, there happens quite often that the float is deserialized to
BigDecimal which is serialized back to string.

```
MultiJson.load(MultiJson.dump(
 MultiJson.load(MultiJson.dump(6.903916489999999))))
```

   # => "6.903916489999999"

Also, other JSON implementations have similar behavior when it takes 
BigDecimal. More details here https://github.com/ohler55/oj/pull/59.

As preserving of the float type is not guaranteed, we need to manually 
typecast to_f to avoid

   Value (String) '3.00232023232032203232' is not any of: Numeric; NilClass
