### PR TITLE
Better handling of databse connections errors

### DIFF
--- a/examples/example_helper.rb
+++ b/examples/example_helper.rb
@@ -13,8 +13,17 @@ class ExampleHelper
       Dynflow::SimpleWorld.new(options)
     end
 
+    def persistence_conn_string
+      ENV['DB_CONN_STRING'] || 'sqlite:/'
+    end
+
+    def persistence_adapter
+      Dynflow::PersistenceAdapters::Sequel.new persistence_conn_string
+    end
+
     def default_world_options
-      { logger_adapter: logger_adapter }
+      { logger_adapter: logger_adapter,
+        persistence_adapter: persistence_adapter }
     end
 
     def logger_adapter

--- a/lib/dynflow/errors.rb
+++ b/lib/dynflow/errors.rb
@@ -24,5 +24,13 @@ module Dynflow
         "#{self.class.inspect}: #{message}"
       end
     end
+
+    class PersistenceError < StandardError
+      def self.delegate(original_exception)
+        self.new("caused by #{original_exception.class}: #{original_exception.message}").tap do |e|
+          e.set_backtrace original_exception.backtrace
+        end
+      end
+    end
   end
 end

--- a/lib/dynflow/executors/parallel.rb
+++ b/lib/dynflow/executors/parallel.rb
@@ -36,8 +36,9 @@ module Dynflow
         variants Work::Step, Work::Event, Work::Finalize
       end
 
-      PoolDone   = Algebrick.type { fields! work: Work }
-      WorkerDone = Algebrick.type { fields! work: Work, worker: Worker }
+      PoolDone       = Algebrick.type { fields! work: Work }
+      PoolTerminated = Algebrick.atom
+      WorkerDone     = Algebrick.type { fields! work: Work, worker: Worker }
 
       def initialize(world, pool_size = 10)
         super(world)

--- a/lib/dynflow/executors/parallel/core.rb
+++ b/lib/dynflow/executors/parallel/core.rb
@@ -25,7 +25,10 @@ module Dynflow
                 end),
                 (on ~Parallel::Event do |event|
                   event(event)
-                end),
+                 end),
+                (on Parallel::PoolTerminated do
+                   finish_termination
+                 end),
                 (on PoolDone.(~any) do |step|
                   update_manager(step)
                 end)
@@ -33,7 +36,7 @@ module Dynflow
 
         def termination
           logger.info 'shutting down Core ...'
-          try_to_terminate
+          @pool << MicroActor::Terminate
         end
 
         # @return false on problem
@@ -85,6 +88,7 @@ module Dynflow
         end
 
         def rescue?(manager)
+          return false if terminating?
           @world.auto_rescue && manager.execution_plan.state == :paused &&
               !@plan_ids_in_rescue.include?(manager.execution_plan.id)
         end
@@ -121,12 +125,15 @@ module Dynflow
         def set_future(manager)
           @plan_ids_in_rescue.delete(manager.execution_plan.id)
           manager.future.resolve manager.execution_plan
-          try_to_terminate
         end
 
 
         def event(event)
           Type! event, Parallel::Event
+          if terminating?
+            raise Dynflow::Error,
+                  "cannot accept event: #{event} core is terminating"
+          end
           execution_plan_manager = @execution_plan_managers[event.execution_plan_id]
           if execution_plan_manager
             feed_pool execution_plan_manager.event(event)
@@ -139,12 +146,16 @@ module Dynflow
           end
         end
 
-        def try_to_terminate
-          if terminating? && @execution_plan_managers.empty?
-            @pool.ask(Terminate).wait
-            logger.info '... Core terminated.'
-            terminate!
+        def finish_termination
+          unless @execution_plan_managers.empty?
+            logger.error "... #{@execution_plan_managers.size} execution plans ..."
+            @execution_plan_managers.values.each do |manager|
+              manager.terminate
+              finish_plan(manager.execution_plan.id)
+            end
           end
+          logger.error '... core terminated.'
+          terminate!
         end
       end
     end

--- a/lib/dynflow/executors/parallel/core.rb
+++ b/lib/dynflow/executors/parallel/core.rb
@@ -148,9 +148,15 @@ module Dynflow
 
         def finish_termination
           unless @execution_plan_managers.empty?
-            logger.error "... #{@execution_plan_managers.size} execution plans ..."
+            logger.error "... cleaning #{@execution_plan_managers.size} execution plans ..."
+            begin
+              @execution_plan_managers.values.each do |manager|
+                manager.terminate
+              end
+            rescue Errors::PersistenceError
+              logger.error "could not to clean the data properly"
+            end
             @execution_plan_managers.values.each do |manager|
-              manager.terminate
               finish_plan(manager.execution_plan.id)
             end
           end

--- a/lib/dynflow/executors/parallel/core.rb
+++ b/lib/dynflow/executors/parallel/core.rb
@@ -139,11 +139,11 @@ module Dynflow
             feed_pool execution_plan_manager.event(event)
             true
           else
-            logger.warn format('dropping event %s - no manager for %s:%s',
-                               event, event.execution_plan_id, event.step_id)
-            event.result.fail UnprocessableEvent.new(
-                                  "no manager for #{event.execution_plan_id}:#{event.step_id}")
+            raise Dynflow::Error, "no manager for #{event.execution_plan_id}:#{event.step_id}"
           end
+        rescue Dynflow::Error => e
+          event.result.fail e.message
+          raise e
         end
 
         def finish_termination

--- a/lib/dynflow/executors/parallel/core.rb
+++ b/lib/dynflow/executors/parallel/core.rb
@@ -31,7 +31,14 @@ module Dynflow
                  end),
                 (on PoolDone.(~any) do |step|
                   update_manager(step)
-                end)
+                 end),
+                (on ~Errors::PersistenceError.to_m do |error|
+                   logger.fatal "PersistenceError in executor: terminating"
+                   logger.fatal error
+                   @world.terminate
+                 end)
+        rescue Errors::PersistenceError => e
+          self << e
         end
 
         def termination

--- a/lib/dynflow/executors/parallel/execution_plan_manager.rb
+++ b/lib/dynflow/executors/parallel/execution_plan_manager.rb
@@ -73,7 +73,9 @@ module Dynflow
 
         def terminate
           @running_steps_manager.terminate
-          @execution_plan.update_state(:paused)
+          unless @execution_plan.state == :paused
+            @execution_plan.update_state(:paused)
+          end
         end
 
         private

--- a/lib/dynflow/executors/parallel/execution_plan_manager.rb
+++ b/lib/dynflow/executors/parallel/execution_plan_manager.rb
@@ -71,6 +71,10 @@ module Dynflow
           (!@run_manager || @run_manager.done?) && (!@finalize_manager || @finalize_manager.done?)
         end
 
+        def terminate
+          @execution_plan.update_state(:paused)
+        end
+
         private
 
         def no_work

--- a/lib/dynflow/executors/parallel/execution_plan_manager.rb
+++ b/lib/dynflow/executors/parallel/execution_plan_manager.rb
@@ -72,6 +72,7 @@ module Dynflow
         end
 
         def terminate
+          @running_steps_manager.terminate
           @execution_plan.update_state(:paused)
         end
 

--- a/lib/dynflow/executors/parallel/running_steps_manager.rb
+++ b/lib/dynflow/executors/parallel/running_steps_manager.rb
@@ -16,7 +16,9 @@ module Dynflow
         def terminate
           pending_work = @events.clear.values.flatten
           pending_work.each do |w|
-            w.event.result.fail UnprocessableEvent.new("dropping due to termination")
+            if Work::Event === w
+              w.event.result.fail UnprocessableEvent.new("dropping due to termination")
+            end
           end
         end
 

--- a/lib/dynflow/executors/parallel/running_steps_manager.rb
+++ b/lib/dynflow/executors/parallel/running_steps_manager.rb
@@ -13,6 +13,13 @@ module Dynflow
           @events        = WorkQueue.new(Integer, Work)
         end
 
+        def terminate
+          pending_work = @events.clear.values.flatten
+          pending_work.each do |w|
+            w.event.result.fail UnprocessableEvent.new("dropping due to termination")
+          end
+        end
+
         def add(step, work)
           Type! step, ExecutionPlan::Steps::RunStep
           @running_steps[step.id] = step

--- a/lib/dynflow/executors/parallel/work_queue.rb
+++ b/lib/dynflow/executors/parallel/work_queue.rb
@@ -29,6 +29,12 @@ module Dynflow
           !present?(key)
         end
 
+        def clear
+          ret = @stash.dup
+          @stash.clear
+          ret
+        end
+
         def size(key)
           return 0 if empty?(key)
           @stash[key].size

--- a/lib/dynflow/executors/parallel/worker.rb
+++ b/lib/dynflow/executors/parallel/worker.rb
@@ -21,7 +21,9 @@ module Dynflow
                 end),
                 (on Work::Finalize.(~any, any) do |sequential_manager|
                   sequential_manager.finalize
-                end)
+                 end)
+        rescue Errors::PersistenceError => e
+          @pool << e
         ensure
           @pool << WorkerDone[work: message, worker: self]
           @transaction_adapter.cleanup

--- a/lib/dynflow/executors/parallel/worker.rb
+++ b/lib/dynflow/executors/parallel/worker.rb
@@ -22,8 +22,8 @@ module Dynflow
                 (on Work::Finalize.(~any, any) do |sequential_manager|
                   sequential_manager.finalize
                 end)
-          @pool << WorkerDone[work: message, worker: self]
         ensure
+          @pool << WorkerDone[work: message, worker: self]
           @transaction_adapter.cleanup
         end
       end

--- a/lib/dynflow/persistence.rb
+++ b/lib/dynflow/persistence.rb
@@ -9,6 +9,7 @@ module Dynflow
     def initialize(world, persistence_adapter)
       @world   = world
       @adapter = persistence_adapter
+      @adapter.register_world(world)
     end
 
     def load_action(step)

--- a/lib/dynflow/persistence_adapters/abstract.rb
+++ b/lib/dynflow/persistence_adapters/abstract.rb
@@ -1,6 +1,14 @@
 module Dynflow
   module PersistenceAdapters
     class Abstract
+
+      # The logger is set by the world when used inside it
+      attr_accessor :logger
+
+      def log(level, message)
+        (logger || Logger.mew($stderr)).send(level, message)
+      end
+
       def pagination?
         false
       end

--- a/lib/dynflow/persistence_adapters/abstract.rb
+++ b/lib/dynflow/persistence_adapters/abstract.rb
@@ -5,8 +5,13 @@ module Dynflow
       # The logger is set by the world when used inside it
       attr_accessor :logger
 
+      def register_world(world)
+        @worlds ||= Set.new
+        @worlds << world
+      end
+
       def log(level, message)
-        (logger || Logger.mew($stderr)).send(level, message)
+        (@worlds.first && @worlds.first.logger).send(level, message)
       end
 
       def pagination?

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -165,15 +165,13 @@ module Dynflow
           yield
         rescue Exception => e
           attempts += 1
+          log(:error, e)
           if attempts > MAX_RETRIES
-            log(:fatal, e)
-            log(:fatal, "Exceeded the number of persistence retries. Terminating.")
-            @worlds.each(&:terminate)
+            log(:error, "The number of MAX_RETRIES exceeded")
             raise Errors::PersistenceError.delegate(e)
           else
-            sleep RETRY_DELAY
-            log(:error, e)
             log(:error, "Persistence retry no. #{attempts}")
+            sleep RETRY_DELAY
             retry
           end
         end

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -164,13 +164,15 @@ module Dynflow
         begin
           yield
         rescue Exception => e
-          log(:error, e)
           attempts += 1
           if attempts > MAX_RETRIES
-            log(:error, "Exceeded the number of persistence retries. Terminating.")
+            log(:fatal, e)
+            log(:fatal, "Exceeded the number of persistence retries. Terminating.")
+            @worlds.each(&:terminate)
             raise Errors::PersistenceError.delegate(e)
           else
             sleep RETRY_DELAY
+            log(:error, e)
             log(:error, "Persistence retry no. #{attempts}")
             retry
           end

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -10,6 +10,7 @@ module Dynflow
       @logger_adapter      = Type! option_val(:logger_adapter), LoggerAdapters::Abstract
       @transaction_adapter = Type! option_val(:transaction_adapter), TransactionAdapters::Abstract
       persistence_adapter  = Type! option_val(:persistence_adapter), PersistenceAdapters::Abstract
+      persistence_adapter.logger ||= logger
       @persistence         = Persistence.new(self, persistence_adapter)
       @executor            = Type! option_val(:executor), Executors::Abstract
       @action_classes      = option_val(:action_classes)

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -10,7 +10,6 @@ module Dynflow
       @logger_adapter      = Type! option_val(:logger_adapter), LoggerAdapters::Abstract
       @transaction_adapter = Type! option_val(:transaction_adapter), TransactionAdapters::Abstract
       persistence_adapter  = Type! option_val(:persistence_adapter), PersistenceAdapters::Abstract
-      persistence_adapter.logger ||= logger
       @persistence         = Persistence.new(self, persistence_adapter)
       @executor            = Type! option_val(:executor), Executors::Abstract
       @action_classes      = option_val(:action_classes)

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -19,6 +19,7 @@ module Dynflow
 
       executor.initialized.wait
       @termination_barrier = Mutex.new
+      @clock_barrier       = Mutex.new
 
       transaction_adapter.check self
     end
@@ -32,7 +33,7 @@ module Dynflow
     end
 
     def clock
-      @clock ||= Clock.new(logger)
+      @clock_barrier.synchronize { @clock ||= Clock.new(logger) }
     end
 
     def logger

--- a/test/remote_via_socket_test.rb
+++ b/test/remote_via_socket_test.rb
@@ -16,6 +16,7 @@ describe 'remote communication' do
     def create_world
       Dynflow::SimpleWorld.new logger_adapter:      logger_adapter,
                                auto_terminate:      false,
+                               exit_on_terminate:   false,
                                persistence_adapter: persistence_adapter
     end
 
@@ -24,6 +25,7 @@ describe 'remote communication' do
           logger_adapter:      logger_adapter,
           auto_terminate:      false,
           persistence_adapter: persistence_adapter,
+          exit_on_terminate:   false,
           executor:            -> remote_world do
             Dynflow::Executors::RemoteViaSocket.new(remote_world, socket_path)
           end)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -116,6 +116,7 @@ module WorldInstance
     options = { pool_size: 5,
                 persistence_adapter: Dynflow::PersistenceAdapters::Sequel.new('sqlite:/'),
                 transaction_adapter: Dynflow::TransactionAdapters::None.new,
+                exit_on_terminate: false,
                 logger_adapter: logger_adapter,
                 auto_rescue: false }.merge(options)
     Dynflow::World.new(options)
@@ -128,6 +129,7 @@ module WorldInstance
     world       = Dynflow::World.new(
         logger_adapter:      logger_adapter,
         auto_terminate:      false,
+        exit_on_terminate:   false,
         persistence_adapter: -> remote_world { world.persistence.adapter },
         transaction_adapter: Dynflow::TransactionAdapters::None.new,
         executor:            -> remote_world do


### PR DESCRIPTION
1. Retry several times when db error occurs
2. Terminate when the retries don't help
3. Let the executor to finish just after the workers are done:
   don't wait for the whole task to finish.