### PR TITLE
Fix tests on random unresolved future

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -171,7 +171,7 @@ future_tests =-> do
   Dynflow::Future.singleton_class.send :define_method, :new do |*args, &block|
     super(*args, &block).tap do |f|
       future_creations[f.object_id]  = caller(3)
-      non_ready_futures[f.object_id] = true
+      non_ready_futures[f.object_id] = f
     end
   end
 


### PR DESCRIPTION
There was a case where an event came right at the time of the core being
terminated, and ended up in the unresolved state.

Handling this in actor by dead letter routing is not as easy as it seems (as
making sure to read all the messages after termination turns out to not be so
straight forward). So for now we just make sure to refuse all the incoming
events as soon as possible.