### PR TITLE
Sub plans support

### DIFF
--- a/examples/sub_plans.rb
+++ b/examples/sub_plans.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+example_description = <<DESC
+  Sub Plans Example
+  ===================
+
+  This example shows, how to trigger the execution plans from within a
+  run method of some action and waing for them to finish.
+
+  This is useful, when doing bulk actions, where having one big
+  execution plan would not be effective, or in case all the data are
+  not available by the time of original action planning.
+
+DESC
+
+require_relative 'example_helper'
+require_relative 'orchestrate_evented'
+
+
+class SubPlansExample < Dynflow::Action
+  include Dynflow::Action::WithSubPlans
+
+  def create_sub_plans
+    10.times.map { |i| trigger(OrchestrateEvented::CreateMachine, "host-#{i}", 'web_server') }
+  end
+end
+
+if $0 == __FILE__
+  triggered = ExampleHelper.world.trigger(SubPlansExample)
+  puts example_description
+  puts <<-MSG.gsub(/^.*\|/, '')
+    |  Execution plan #{triggered.id} with sub plans triggered
+    |  You can see the details at http://localhost:4567/#{triggered.id}
+  MSG
+
+  ExampleHelper.run_web_console
+end

--- a/lib/dynflow/action/with_sub_plans.rb
+++ b/lib/dynflow/action/with_sub_plans.rb
@@ -1,0 +1,161 @@
+module Dynflow
+  module Action::WithSubPlans
+    SubPlanFinished = Algebrick.type do
+      fields! :execution_plan_id => String,
+              :success           => type { variants TrueClass, FalseClass }
+    end
+
+    def run(event = nil)
+      case(event)
+      when nil
+        if output[:total_count]
+          resume
+        else
+          initiate
+        end
+      when SubPlanFinished
+        mark_as_done(event.execution_plan_id, event.success)
+        try_to_finish or suspend
+      end
+    end
+
+    def initiate
+      sub_plans = create_sub_plans
+      sub_plans = Array[sub_plans] unless sub_plans.is_a? Array
+      wait_for_sub_plans(sub_plans)
+    end
+
+    # @api override when the logic for the initiation of the subtasks
+    #      is different from the default one.
+    # @returns a triggered task or array of triggered tasks
+    # @example
+    #
+    #        def create_sub_plans
+    #          trigger(MyAction, "Hello")
+    #        end
+    #
+    # @example
+    #
+    #        def create_sub_plans
+    #          [trigger(MyAction, "Hello 1"), trigger(MyAction, "Hello 2")]
+    #        end
+    #
+    def create_sub_plans
+      raise NotImplementedError
+    end
+
+    # @api method to be called after all the sub tasks finished
+    def on_finish
+    end
+
+    # Helper for creating sub plans
+    def trigger(*args)
+      world.trigger do
+        world.plan_with_caller(self, *args)
+      end
+    end
+
+    def wait_for_sub_plans(sub_plans)
+      output.update(total_count: 0,
+                    failed_count: 0,
+                    success_count: 0)
+
+      planned, failed = sub_plans.partition(&:planned?)
+
+      sub_plan_ids = ((planned + failed).map(&:execution_plan_id))
+
+      output[:total_count] = sub_plan_ids.size
+      output[:failed_count] = failed.size
+
+      if planned.any?
+        notify_on_finish(planned)
+      else
+        check_for_errors!
+      end
+    end
+
+    def try_to_finish
+      if done?
+        check_for_errors!
+        on_finish
+        return true
+      else
+        return false
+      end
+    end
+
+    def resume
+      if sub_plans.all? { |sub_plan| sub_plan.error_in_plan? }
+        initiate
+      else
+        recalculate_counts
+        try_to_finish or fail "Some sub plans are still not finished"
+      end
+    end
+
+    def sub_plans
+      @sub_plans ||= world.persistence.find_execution_plans(filters: { 'caller_execution_plan_id' => execution_plan_id,
+                                                                       'caller_action_id' => self.id } )
+    end
+
+    def notify_on_finish(plans)
+      suspend do |suspended_action|
+        plans.each do |plan|
+          plan.finished.do_then do |value|
+            suspended_action << SubPlanFinished[plan.execution_plan_id,
+                                                value.result == :success]
+          end
+        end
+      end
+    end
+
+    def mark_as_done(plan_id, success)
+      if success
+        output[:success_count] += 1
+      else
+        output[:failed_count] += 1
+      end
+    end
+
+    def done?
+      if counts_set?
+        output[:total_count] - output[:success_count] - output[:failed_count] <= 0
+      else
+        false
+      end
+    end
+
+    def run_progress
+      if counts_set? && output[:total_count] > 0
+        (output[:success_count] + output[:failed_count]).to_f / output[:total_count]
+      else
+        0.1
+      end
+    end
+
+    def recalculate_counts
+      output.update(total_count: 0,
+                    failed_count: 0,
+                    success_count: 0)
+      sub_plans.each do |sub_plan|
+        output[:total_count] += 1
+        if sub_plan.state == :stopped
+          if sub_plan.error?
+            output[:failed_count] += 1
+          else
+            output[:success_count] += 1
+          end
+        end
+      end
+    end
+
+    def counts_set?
+      output[:total_count] && output[:success_count] && output[:failed_count]
+    end
+
+    def check_for_errors!
+      fail "A sub task failed" if output[:failed_count] > 0
+    end
+
+  end
+end

--- a/lib/dynflow/execution_plan/steps/abstract.rb
+++ b/lib/dynflow/execution_plan/steps/abstract.rb
@@ -124,6 +124,10 @@ module Dynflow
         false
       end
 
+      def with_sub_plans?
+        false
+      end
+
       protected
 
       def self.new_from_hash(hash, execution_plan_id, world)

--- a/lib/dynflow/execution_plan/steps/abstract.rb
+++ b/lib/dynflow/execution_plan/steps/abstract.rb
@@ -113,8 +113,7 @@ module Dynflow
       # @return [Action] in presentation mode, intended for retrieving: progress information,
       # details, human outputs, etc.
       def action(execution_plan)
-        attributes = world.persistence.adapter.load_action(execution_plan_id, action_id)
-        Action.from_hash(attributes.update(phase: Action::Present, execution_plan: execution_plan), world)
+        world.persistence.load_action_for_presentation(execution_plan, action_id)
       end
 
       def skippable?

--- a/lib/dynflow/execution_plan/steps/plan_step.rb
+++ b/lib/dynflow/execution_plan/steps/plan_step.rb
@@ -76,14 +76,18 @@ module Dynflow
             hash[:children]
       end
 
-      def initialize_action
+      def initialize_action(caller_action)
         attributes = { execution_plan_id: execution_plan_id,
                        id:                action_id,
                        step:              self,
                        plan_step_id:      self.id,
                        run_step_id:       nil,
                        finalize_step_id:  nil,
-                       phase:             phase}
+                       phase:             phase }
+        if caller_action
+          attributes.update(caller_execution_plan_id: caller_action.execution_plan_id,
+                            caller_action_id:         caller_action.id)
+        end
         @action = action_class.new(attributes, world)
         persistence.save_action(execution_plan_id, @action)
         @action

--- a/lib/dynflow/execution_plan/steps/run_step.rb
+++ b/lib/dynflow/execution_plan/steps/run_step.rb
@@ -23,6 +23,10 @@ module Dynflow
             self.action_class < Action::Cancellable
       end
 
+      def with_sub_plans?
+        self.action_class < Action::WithSubPlans
+      end
+
       def mark_to_skip
         case self.state
         when :error

--- a/lib/dynflow/persistence.rb
+++ b/lib/dynflow/persistence.rb
@@ -19,6 +19,11 @@ module Dynflow
       return Action.from_hash(attributes, step.world)
     end
 
+    def load_action_for_presentation(execution_plan, action_id)
+      attributes = adapter.load_action(execution_plan.id, action_id)
+      Action.from_hash(attributes.update(phase: Action::Present, execution_plan: execution_plan), @world)
+    end
+
     def save_action(execution_plan_id, action)
       adapter.save_action(execution_plan_id, action.id, action.to_hash)
     end

--- a/lib/dynflow/persistence_adapters/sequel_migrations/003_parent_action.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/003_parent_action.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  change do
+    alter_table(:dynflow_actions) do
+      add_column :caller_execution_plan_id, String, fixed: true, size: 36
+      add_column :caller_action_id, Fixnum
+      add_index [:caller_execution_plan_id, :caller_action_id]
+    end
+  end
+end

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -91,8 +91,14 @@ module Dynflow
 
     # @return [TriggerResult]
     # blocks until action_class is planned
-    def trigger(action_class, *args)
-      execution_plan = plan(action_class, *args)
+    # if no arguments given, the plan is expected to be returned by a block
+    def trigger(action_class = nil, *args, &block)
+      if action_class.nil?
+        raise 'Neither action_class nor a block given' if block.nil?
+        execution_plan = block.call(self)
+      else
+        execution_plan = plan(action_class, *args)
+      end
       planned        = execution_plan.state == :planned
 
       if planned
@@ -120,6 +126,13 @@ module Dynflow
     def plan(action_class, *args)
       ExecutionPlan.new(self).tap do |execution_plan|
         execution_plan.prepare(action_class)
+        execution_plan.plan(*args)
+      end
+    end
+
+    def plan_with_caller(caller_action, action_class, *args)
+      ExecutionPlan.new(self).tap do |execution_plan|
+        execution_plan.prepare(action_class, caller_action: caller_action)
         execution_plan.plan(*args)
       end
     end

--- a/test/persistance_adapters_test.rb
+++ b/test/persistance_adapters_test.rb
@@ -87,13 +87,13 @@ module PersistenceAdapterTest
              real_time: 0.0, execution_time: 0.0 }
     storage.save_execution_plan('plan1', plan)
 
-    action = { id: 1 }
+    action = { id: 1, caller_execution_plan_id: nil, caller_action_id: nil }
     -> { storage.load_action('plan1', 1) }.must_raise KeyError
 
     storage.save_action('plan1', 1, action)
     storage.load_action('plan1', 1)[:id].must_equal 1
     storage.load_action('plan1', 1)['id'].must_equal 1
-    storage.load_action('plan1', 1).keys.size.must_equal 1
+    storage.load_action('plan1', 1).keys.must_equal %w[id caller_execution_plan_id caller_action_id]
 
     storage.save_action('plan1', 1, nil)
     -> { storage.load_action('plan1', 1) }.must_raise KeyError

--- a/web/views/flow_step.erb
+++ b/web/views/flow_step.erb
@@ -14,6 +14,9 @@
 <% if @plan.state == :paused && step.skippable? %>
   <a href="<%= url("/#{@plan.id}/skip/#{step.id}") %>" class="postlink">Skip</a>
 <% end %>
+<% if step.with_sub_plans? %>
+  <a href="<%= url("/#{@plan.id}/actions/#{step.action_id}/sub_plans") %>">Sub plans</a>
+<% end %>
 <% if step.cancellable? %>
   <a href="<%= url("/#{@plan.id}/cancel/#{step.id}") %>" class="postlink">Cancel</a>
 <% end %>


### PR DESCRIPTION
This patch adds support for triggering execution plans from a run phase
(a.k.a sub-plans) and waiting for the sub-plans to finish.

It's as simple as:

```ruby
   class ActionWithSubPlan < Dynflow::Action
     include Dynflow::Action::WithSubPlans

      def create_sub_plans
       10.times.map { trigger(SomeAction, input) }
     end
   end
```

The `Action::WithSubPlans` defines the `run` method and expects the action
to define `create_sub_plans` to return one or many triggered actions. The
`WithSubPlans` module takes care of waiting for the sub plans to finish,
and succeeding or failing after that.

The resuming behaviour can be also customized, by overriding the `resume`
method. By default, it re-creates the sub plans in case none of the sub
plans was planned successfully. Otherwise it checks, that all the sub plans
have already finished and fails when they haven't.

To support this, the caller_execution_plan_id and caller_action_id
attributes were added to the action, to track this relation. The relation
between actions in one execution plan is tracked the same way as well, with
the prospect of using this data instead of the data in execution plan later
(but we are not there yet).

In the web console, the Action::WithSubPlans shows link to the list of sub
plans in the console.

Also, an example of the sub plans is available in examples directory for
seeing this functionality in cation.