### PR TITLE
Allow using suspended_action reference before calling the suspend method

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -371,9 +371,14 @@ module Dynflow
 
     # DSL for run phase
 
+    def suspended_action
+      phase! Run
+      @suspended_action ||= Action::Suspended.new(self)
+    end
+
     def suspend(&block)
       phase! Run
-      block.call Action::Suspended.new self if block
+      block.call suspended_action if block
       throw SUSPEND, SUSPEND
     end
 


### PR DESCRIPTION
The usage of suspend with block to get the suspended action reference is a bit
clumsy. This should help a bit with the readability.