### PR TITLE
adding simple polling timeout mechanism

### DIFF
--- a/lib/dynflow/action/polling.rb
+++ b/lib/dynflow/action/polling.rb
@@ -1,5 +1,11 @@
+require 'dynflow/action/timeouts'
+
 module Dynflow
   module Action::Polling
+
+    def self.included(base)
+      base.send :include, Action::Timeouts
+    end
 
     Poll = Algebrick.atom
 
@@ -13,6 +19,9 @@ module Dynflow
         end
       when Poll
         poll_external_task_with_rescue
+      when Action::Timeouts::Timeout
+        process_timeout
+        suspend
       else
         raise "unrecognized event #{event}"
       end

--- a/lib/dynflow/action/timeouts.rb
+++ b/lib/dynflow/action/timeouts.rb
@@ -1,0 +1,13 @@
+module Dynflow
+  module Action::Timeouts
+    Timeout = Algebrick.atom
+
+    def process_timeout
+      fail("Timeout exceeded.")
+    end
+
+    def schedule_timeout(seconds)
+      world.clock.ping suspended_action, seconds, Timeout
+    end
+ end
+end

--- a/lib/dynflow/testing/dummy_executor.rb
+++ b/lib/dynflow/testing/dummy_executor.rb
@@ -12,11 +12,15 @@ module Dynflow
         @events_to_process << [execution_plan_id, step_id, event, future]
       end
 
+      # returns true if some event was processed.
       def progress
         events = @events_to_process.dup
         clear
         events.each do |execution_plan_id, step_id, event, future|
           future.resolve true
+          if event && world.action.state != :suspended
+            return false
+          end
           world.action.execute event
         end
       end

--- a/lib/dynflow/testing/factories.rb
+++ b/lib/dynflow/testing/factories.rb
@@ -97,8 +97,9 @@ module Dynflow
 
       def progress_action_time action
         Match! action.phase, Action::Run
-        action.world.clock.progress
-        action.world.executor.progress
+        if action.world.clock.progress
+          return action.world.executor.progress
+        end
       end
     end
   end

--- a/lib/dynflow/testing/managed_clock.rb
+++ b/lib/dynflow/testing/managed_clock.rb
@@ -5,30 +5,29 @@ module Dynflow
       attr_reader :pending_pings
 
       include Algebrick::Types
-      Timer = Algebrick.type do
-        fields! who:   Object, # to ping back
-                when:  type { variants Time, Numeric }, # to deliver
-                what:  Maybe[Object], # to send
-                where: Symbol # it should be delivered, which method
-      end
-
-      module Timer
-        include Clock::Timer
-      end
 
       def initialize
         @pending_pings = []
       end
 
       def ping(who, time, with_what = nil, where = :<<)
+        time  = current_time + time if time.is_a? Numeric
         with = with_what.nil? ? None : Some[Object][with_what]
-        @pending_pings << Timer[who, time, with, where]
+        @pending_pings << Clock::Timer[who, time, with, where]
+        @pending_pings.sort!
       end
 
       def progress
-        copy = @pending_pings.dup
-        clear
-        copy.each { |ping| ping.apply }
+        if next_ping = @pending_pings.shift
+          # we are testing an isolated system = we can move in time
+          # without actually waiting
+          @current_time = next_ping.when
+          next_ping.apply
+        end
+      end
+
+      def current_time
+        @current_time ||= Time.now
       end
 
       def clear

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -266,14 +266,18 @@ module Dynflow
 
         it 'allows increasing poll interval in a time' do
           TestPollingAction.config.poll_intervals = [1, 2]
-          TestPollingAction.config.attempts_before_next_interval = 1
+          TestPollingAction.config.attempts_before_next_interval = 2
 
           action   = run_action plan
-          next_ping(action).when.must_equal 1
+          pings = []
+          pings << next_ping(action)
           progress_action_time action
-          next_ping(action).when.must_equal 2
+          pings << next_ping(action)
           progress_action_time action
-          next_ping(action).when.must_equal 2
+          pings << next_ping(action)
+          progress_action_time action
+          (pings[1].when - pings[0].when).must_be_close_to 1
+          (pings[2].when - pings[1].when).must_be_close_to 2
         end
       end
 

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -172,85 +172,134 @@ module Dynflow
         end
       end
 
-      let(:plan) do
-        create_and_plan_action TestPollingAction, { task_args: 'do something' }
+      class NonRunningExternalService < ExternalService
+        def poll(id)
+          return { message: 'nothing changed' }
+        end
       end
 
-      before do
-        TestPollingAction.config = TestPollingAction::Config.new
-      end
-
-      def next_ping(action)
-        action.world.clock.pending_pings.first
-      end
-
-      it 'initiates the external task' do
-        action   = run_action plan
-
-        action.output[:task][:task_id].must_equal 123
-      end
-
-      it 'polls till the task is done' do
-        action   = run_action plan
-
-        9.times { progress_action_time action }
-        action.done?.must_equal false
-        next_ping(action).wont_be_nil
-        action.state.must_equal :suspended
-
-        progress_action_time action
-        action.done?.must_equal true
-        next_ping(action).must_be_nil
-        action.state.must_equal :success
-      end
-
-      it 'tries to poll for the old task when resuming' do
-        action   = run_action plan
-        action.output[:task][:progress].must_equal 0
-        run_action action
-        action.output[:task][:progress].must_equal 10
-      end
-
-      it 'invokes the external task again when polling on the old one fails' do
-        action   = run_action plan
-        action.world.silence_logger!
-        action.external_service.will_fail
-        action.output[:task][:progress].must_equal 0
-        run_action action
-        action.output[:task][:progress].must_equal 0
-      end
-
-      it 'tolerates some failure while polling' do
-        action   = run_action plan
-        action.external_service.will_fail
-        action.world.silence_logger!
-
-        TestPollingAction.config.poll_max_retries = 3
-        (1..2).each do |attempt|
-          progress_action_time action
-          action.poll_attempts[:failed].must_equal attempt
-          next_ping(action).wont_be_nil
-          action.state.must_equal :suspended
+      class TestTimeoutAction < TestPollingAction
+        class Config < TestPollingAction::Config
+          def initialize
+            super
+            @external_service = NonRunningExternalService.new
+          end
         end
 
-        progress_action_time action
-        action.poll_attempts[:failed].must_equal 3
-        next_ping(action).must_be_nil
-        action.state.must_equal :error
+        def done?
+          self.state == :error
+        end
+
+        def invoke_external_task
+          schedule_timeout(5)
+          super
+        end
       end
 
-      it 'allows increasing poll interval in a time' do
-        TestPollingAction.config.poll_intervals = [1, 2]
-        TestPollingAction.config.attempts_before_next_interval = 1
+      describe'without timeout' do
+        let(:plan) do
+          create_and_plan_action TestPollingAction, { task_args: 'do something' }
+        end
 
-        action   = run_action plan
-        next_ping(action).when.must_equal 1
-        progress_action_time action
-        next_ping(action).when.must_equal 2
-        progress_action_time action
-        next_ping(action).when.must_equal 2
+        before do
+          TestPollingAction.config = TestPollingAction::Config.new
+        end
+
+        def next_ping(action)
+          action.world.clock.pending_pings.first
+        end
+
+        it 'initiates the external task' do
+          action   = run_action plan
+
+          action.output[:task][:task_id].must_equal 123
+        end
+
+        it 'polls till the task is done' do
+          action   = run_action plan
+
+          9.times { progress_action_time action }
+          action.done?.must_equal false
+          next_ping(action).wont_be_nil
+          action.state.must_equal :suspended
+
+          progress_action_time action
+          action.done?.must_equal true
+          next_ping(action).must_be_nil
+          action.state.must_equal :success
+        end
+
+        it 'tries to poll for the old task when resuming' do
+          action   = run_action plan
+          action.output[:task][:progress].must_equal 0
+          run_action action
+          action.output[:task][:progress].must_equal 10
+        end
+
+        it 'invokes the external task again when polling on the old one fails' do
+          action   = run_action plan
+          action.world.silence_logger!
+          action.external_service.will_fail
+          action.output[:task][:progress].must_equal 0
+          run_action action
+          action.output[:task][:progress].must_equal 0
+        end
+
+        it 'tolerates some failure while polling' do
+          action   = run_action plan
+          action.external_service.will_fail
+          action.world.silence_logger!
+
+          TestPollingAction.config.poll_max_retries = 3
+          (1..2).each do |attempt|
+            progress_action_time action
+            action.poll_attempts[:failed].must_equal attempt
+            next_ping(action).wont_be_nil
+            action.state.must_equal :suspended
+          end
+
+          progress_action_time action
+          action.poll_attempts[:failed].must_equal 3
+          next_ping(action).must_be_nil
+          action.state.must_equal :error
+        end
+
+        it 'allows increasing poll interval in a time' do
+          TestPollingAction.config.poll_intervals = [1, 2]
+          TestPollingAction.config.attempts_before_next_interval = 1
+
+          action   = run_action plan
+          next_ping(action).when.must_equal 1
+          progress_action_time action
+          next_ping(action).when.must_equal 2
+          progress_action_time action
+          next_ping(action).when.must_equal 2
+        end
       end
 
+      describe 'with timeout' do
+        let(:plan) do
+          create_and_plan_action TestTimeoutAction, { task_args: 'do something' }
+        end
+
+        before do
+          TestTimeoutAction.config = TestTimeoutAction::Config.new
+          TestTimeoutAction.config.poll_intervals = [2]
+        end
+
+        it 'timesout' do
+          action   = run_action plan
+          iterations = 0
+          while progress_action_time action
+            # we count the number of iterations till the timeout occurs
+            iterations += 1
+          end
+          action.state.must_equal :error
+          # two polls in 2 seconds intervals untill the 5 seconds
+          # timeout appears
+          iterations.must_equal 3
+        end
+      end
     end
 
     describe Action::WithSubPlans do


### PR DESCRIPTION
This adds the ability for an action to call schedule_timeout(50), to
schedule when the polling should stop and the task be marked as failed.
In this simple implementation the above would cause the task to fail after 50
seconds.  Actions could override process_timeout to do more advanced things