### PR TITLE
fix spelling of assert methods

### DIFF
--- a/doc/pages/source/documentation/index.md
+++ b/doc/pages/source/documentation/index.md
@@ -486,7 +486,7 @@ def plan
   # so it's added to the above sequence to be executed as 4th.
   action1 = plan_action AnAction, actions_executed_sequentially.last.output
 
-  # It's planed in default plan's concurrency scope it's executed concurrently
+  # It's planned in default plan's concurrency scope it's executed concurrently
   # to about four actions.
   action2 = plan_action AnAction
 end

--- a/lib/dynflow/testing/assertions.rb
+++ b/lib/dynflow/testing/assertions.rb
@@ -3,7 +3,7 @@ module Dynflow
     module Assertions
       # assert that +assert_actioned_plan+ was planned by +action+ with arguments +plan_input+
       # alternatively plan-input can be asserted with +block+
-      def assert_action_planed_with(action, planned_action_class, *plan_input, &block)
+      def assert_action_planned_with(action, planned_action_class, *plan_input, &block)
         found_classes = assert_action_planed(action, planned_action_class)
         found         = found_classes.select do |a|
           if plan_input.empty?
@@ -20,7 +20,7 @@ module Dynflow
       end
 
       # assert that +assert_actioned_plan+ was planned by +action+
-      def assert_action_planed(action, planned_action_class)
+      def assert_action_planned(action, planned_action_class)
         Match! action.phase, Action::Plan
         Match! action.state, :success
         found = action.execution_plan.planned_plan_steps.
@@ -30,7 +30,7 @@ module Dynflow
         found
       end
 
-      def refute_action_planed(action, planned_action_class)
+      def refute_action_planned(action, planned_action_class)
         Match! action.phase, Action::Plan
         Match! action.state, :success
         found = action.execution_plan.planned_plan_steps.
@@ -39,6 +39,10 @@ module Dynflow
         assert(found.empty?, "Action #{planned_action_class} was planned")
         found
       end
+
+      alias :assert_action_planed_with :assert_action_planned_with
+      alias :assert_action_planed :assert_action_planned
+      alias :refute_action_planed :refute_action_planned
 
       # assert that +action+ has run-phase planned
       def assert_run_phase(action, input = nil, &block)

--- a/test/testing_test.rb
+++ b/test/testing_test.rb
@@ -20,8 +20,8 @@ module Dynflow
         action.state.must_equal :success
         assert_run_phase action
         assert_finalize_phase action
-        assert_action_planed action, CWE::DummySuspended
-        refute_action_planed action, CWE::DummyAnotherTrigger
+        assert_action_planned action, CWE::DummySuspended
+        refute_action_planned action, CWE::DummyAnotherTrigger
       end
 
       specify 'stub_plan_action' do
@@ -103,11 +103,11 @@ module Dynflow
           refute_run_phase action
           refute_finalize_phase action
 
-          assert_action_planed action, CWE::Ci
-          assert_action_planed_with action, CWE::Review do |_, name, _|
+          assert_action_planned action, CWE::Ci
+          assert_action_planned_with action, CWE::Review do |_, name, _|
             name == 'Morfeus'
           end
-          assert_action_planed_with action, CWE::Review, sha, 'Neo', true
+          assert_action_planned_with action, CWE::Review, sha, 'Neo', true
         end
       end
 


### PR DESCRIPTION
The names of the some of the assert methods in assertions.rb are misspelled. This pull request fixes the spelling while also aliasing the old names so that you won't break anyone who is currently using them.