### PR TITLE
Allow describing the action state in more user-oriented way

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -246,6 +246,12 @@ module Dynflow
       @step.state
     end
 
+    # @override to define more descriptive state information for the
+    # action: used in Dynflow console
+    def humanized_state
+      state.to_s
+    end
+
     def error
       phase! Executable
       @step.error

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -91,6 +91,32 @@ module Dynflow
       end
     end
 
+    describe '#humanized_state' do
+      include WorldInstance
+      include Testing
+
+      class ActionWithHumanizedState < Dynflow::Action
+        def run(event = nil)
+          suspend unless event
+        end
+
+        def humanized_state
+          case state
+          when :suspended
+            "waiting"
+          else
+            super
+          end
+        end
+      end
+
+      it 'is customizable from an action' do
+        plan   = create_and_plan_action ActionWithHumanizedState, {}
+        action = run_action(plan)
+        action.humanized_state.must_equal "waiting"
+      end
+    end
+
     describe 'polling action' do
       CWE = Support::CodeWorkflowExample
       include Dynflow::Testing

--- a/web/views/flow_step.erb
+++ b/web/views/flow_step.erb
@@ -6,7 +6,7 @@
 
 <span class="step-label">
   <%= h(step.id) %>: <%= h(step.action_class.name) %>
-  (<%= h(step.state) %>)
+  (<%= h(action.humanized_state) %>)
   <% unless step.state == :pending %>
     [ <%= duration_to_s(step.real_time) %> / <%= duration_to_s(step.execution_time) %> ]
   <% end %>


### PR DESCRIPTION
The 'suspended' state might be misleading for some users not familiar much
with the dynflow terminology.