### PR TITLE
require 'sinatra/base' instead of 'sinatra'

### DIFF
--- a/lib/dynflow/web_console.rb
+++ b/lib/dynflow/web_console.rb
@@ -1,6 +1,6 @@
 require 'dynflow'
 require 'pp'
-require 'sinatra'
+require 'sinatra/base'
 require 'yaml'
 
 module Dynflow


### PR DESCRIPTION
The 'sinatra' requires 'sinatra/main', which in 1.3.x version included some 
global methods and conflicted with others.