### PR TITLE
Limit the size of coordinator record id/class

### DIFF
--- a/lib/dynflow/coordinator.rb
+++ b/lib/dynflow/coordinator.rb
@@ -62,6 +62,8 @@ module Dynflow
       def validate!
         Type! id,       String
         Type! @data,     Hash
+        raise "The record id %{s} too large" % id if id.size > 100
+        raise "The record class name %{s} too large" % self.class.name if self.class.name.size > 100
       end
 
       def to_s

--- a/lib/dynflow/persistence_adapters/sequel_migrations/004_coordinator_records.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/004_coordinator_records.rb
@@ -1,8 +1,8 @@
 Sequel.migration do
   change do
     create_table(:dynflow_coordinator_records) do
-      column :id, String
-      column :class, String
+      column :id, String, size: 100
+      column :class, String, size: 100
       primary_key [:id, :class]
       index :class
       column :owner_id, String


### PR DESCRIPTION
Some versions of MySQL seem to have issues with too big column indexes