### PR TITLE
Put the default value for auto_rescue back to true

### DIFF
--- a/lib/dynflow/config.rb
+++ b/lib/dynflow/config.rb
@@ -70,7 +70,7 @@ module Dynflow
     end
 
     config_attr :auto_rescue, Algebrick::Types::Boolean do
-      false
+      true
     end
 
     config_attr :exit_on_terminate, Algebrick::Types::Boolean do


### PR DESCRIPTION
The users should opt out, not opt in for this feature