### PR TITLE
Better progress reporting for pending/scheduled plans

### DIFF
--- a/examples/future_execution.rb
+++ b/examples/future_execution.rb
@@ -12,13 +12,13 @@ class CustomPassedObject
 end
 
 class CustomPassedObjectSerializer < ::Dynflow::Serializers::Abstract
-  def serialize(*args)
+  def serialize
     object = args.first
     # Serialized output can be anything that is representable as JSON: Array, Hash...
     { :id => object.id, :name => object.name }
   end
 
-  def deserialize(serialized_args)
+  def deserialize
     # Deserialized output must be an Array
     [CustomPassedObject.new(serialized_args[:id], serialized_args[:name])]
   end
@@ -27,7 +27,7 @@ end
 class DelayedAction < Dynflow::Action
 
   def schedule(schedule_options, *args)
-    CustomPassedObjectSerializer.new
+    CustomPassedObjectSerializer.new(args)
   end
 
   def plan(passed_object)

--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -323,6 +323,7 @@ module Dynflow
     # @return [0..1] the percentage of the progress. See Action::Progress for more
     # info
     def progress
+      return 0 if [:pending, :planning, :scheduled].include?(state)
       flow_step_ids         = run_flow.all_step_ids + finalize_flow.all_step_ids
       plan_done, plan_total = flow_step_ids.reduce([0.0, 0]) do |(done, total), step_id|
         step = self.steps[step_id]

--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -20,7 +20,7 @@ module Dynflow
     end
 
     def self.state_transitions
-      @state_transitions ||= { pending:  [:scheduled, :planning],
+      @state_transitions ||= { pending:  [:stopped, :scheduled, :planning],
                                scheduled: [:planning, :stopped],
                                planning: [:planned, :stopped],
                                planned:  [:running],
@@ -152,11 +152,19 @@ module Dynflow
       @last_step_id += 1
     end
 
-    def schedule(action_class, options, schedule_options, *args)
-      prepare(action_class, options)
+    def schedule(action_class, schedule_options, *args)
+      save
+      @root_plan_step = add_scheduling_step(action_class)
       execution_history.add("schedule", @world.id)
-      update_state :scheduled
-      entry_action.execute_schedule(schedule_options, args)
+      serializer = root_plan_step.schedule(schedule_options, args)
+      scheduled_plan = ScheduledPlan.new(@world,
+                                         id,
+                                         schedule_options[:start_at],
+                                         schedule_options.fetch(:start_before, nil),
+                                         serializer)
+      persistence.save_scheduled_plan(scheduled_plan)
+    ensure
+      update_state(error? ? :stopped : :scheduled)
     end
 
     def schedule_record
@@ -249,6 +257,12 @@ module Dynflow
     ensure
       @run_flow_stack.pop
       current_run_flow.add_and_resolve(@dependency_graph, new_flow) if current_run_flow
+    end
+
+    def add_scheduling_step(action_class)
+      add_step(Steps::PlanStep, action_class, generate_action_id, :scheduling).tap do |step|
+        step.initialize_action
+      end
     end
 
     def add_plan_step(action_class, caller_action = nil)
@@ -354,10 +368,10 @@ module Dynflow
       world.persistence
     end
 
-    def add_step(step_class, action_class, action_id)
+    def add_step(step_class, action_class, action_id, state = :pending)
       step_class.new(self.id,
                      self.generate_step_id,
-                     :pending,
+                     state,
                      action_class,
                      action_id,
                      nil,

--- a/lib/dynflow/execution_plan/steps/abstract.rb
+++ b/lib/dynflow/execution_plan/steps/abstract.rb
@@ -63,7 +63,7 @@ module Dynflow
       end
 
       def self.states
-        @states ||= [:pending, :running, :success, :suspended, :skipping, :skipped, :error]
+        @states ||= [:scheduling, :pending, :running, :success, :suspended, :skipping, :skipped, :error]
       end
 
       def execute(*args)

--- a/lib/dynflow/persistence.rb
+++ b/lib/dynflow/persistence.rb
@@ -65,6 +65,7 @@ module Dynflow
 
     def load_scheduled_plan(execution_plan_id)
       hash = adapter.load_scheduled_plan(execution_plan_id)
+      return nil unless hash
       ScheduledPlan.new_from_hash(@world, hash)
     end
 

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -100,6 +100,8 @@ module Dynflow
 
       def load_scheduled_plan(execution_plan_id)
         load :scheduled, execution_plan_uuid: execution_plan_id
+      rescue KeyError
+        return nil
       end
 
       def save_scheduled_plan(execution_plan_id, value)

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -63,6 +63,7 @@ module Dynflow
         filter(:execution_plan, table(:execution_plan), filters).each_slice(batch_size) do |plans|
           uuids = plans.map { |p| p.fetch(:uuid) }
           @db.transaction do
+            table(:scheduled).where(execution_plan_uuid: uuids).delete
             table(:step).where(execution_plan_uuid: uuids).delete
             table(:action).where(execution_plan_uuid: uuids).delete
             count += table(:execution_plan).where(uuid: uuids).delete

--- a/lib/dynflow/scheduled_plan.rb
+++ b/lib/dynflow/scheduled_plan.rb
@@ -3,7 +3,7 @@ module Dynflow
 
     include Algebrick::TypeCheck
 
-    attr_reader :execution_plan_uuid, :start_at, :start_before, :args
+    attr_reader :execution_plan_uuid, :start_at, :start_before
 
     def initialize(world, execution_plan_uuid, start_at, start_before, args_serializer)
       @world               = Type! world, World
@@ -44,13 +44,13 @@ module Dynflow
        recursive_to_hash :execution_plan_uuid => @execution_plan_uuid,
                          :start_at            => time_to_str(@start_at),
                          :start_before        => time_to_str(@start_before),
-                         :args                => @args_serializer.serialized_args,
+                         :serialized_args     => @args_serializer.serialized_args,
                          :args_serializer     => @args_serializer.class.name
     end
 
     # @api private
     def self.new_from_hash(world, hash, *args)
-      serializer = hash[:args_serializer].constantize.new(nil, hash[:args])
+      serializer = hash[:args_serializer].constantize.new(nil, hash[:serialized_args])
       self.new(world,
                hash[:execution_plan_uuid],
                string_to_time(hash[:start_at]),

--- a/lib/dynflow/serializers/abstract.rb
+++ b/lib/dynflow/serializers/abstract.rb
@@ -2,11 +2,37 @@ module Dynflow
   module Serializers
     class Abstract
 
-      def serialize(*args)
+      attr_reader :args, :serialized_args
+
+      def initialize(args, serialized_args = nil)
+        @args = args
+        @serialized_args = serialized_args
+      end
+
+      def args
+        raise "@args not set" if @args.nil?
+        return @args
+      end
+
+      def serialized_args
+        raise "@serialized_args not set" if @serialized_args.nil?
+        return @serialized_args
+      end
+
+      def perform_serialization!
+        @serialized_args = serialize
+      end
+
+      def perform_deserialization!
+        raise "@serialized_args not set" if @serialized_args.nil?
+        @args = deserialize
+      end
+
+      def serialize
         raise NotImplementedError
       end
 
-      def deserialize(serialized_args)
+      def deserialize
         raise NotImplementedError
       end
 

--- a/lib/dynflow/serializers/noop.rb
+++ b/lib/dynflow/serializers/noop.rb
@@ -2,11 +2,11 @@ module Dynflow
   module Serializers
     class Noop < Abstract
 
-      def serialize(*args)
+      def serialize
         args
       end
 
-      def deserialize(serialized_args)
+      def deserialize
         serialized_args
       end
 

--- a/lib/dynflow/web/console_helpers.rb
+++ b/lib/dynflow/web/console_helpers.rb
@@ -114,7 +114,7 @@ module Dynflow
         when :success
           "success"
         when :error
-          "important"
+          "danger"
         else
           "default"
         end

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -149,14 +149,7 @@ module Dynflow
     def schedule(action_class, schedule_options, *args)
       raise 'No action_class given' if action_class.nil?
       execution_plan = ExecutionPlan.new self
-      execution_plan.schedule(action_class, {}, schedule_options, *args)
-      scheduled_plan = ScheduledPlan.new(self,
-                                         execution_plan.id,
-                                         schedule_options[:start_at],
-                                         schedule_options.fetch(:start_before, nil),
-                                         args,
-                                         execution_plan.entry_action.serializer)
-      persistence.save_scheduled_plan(scheduled_plan)
+      execution_plan.schedule(action_class, schedule_options, *args)
       Scheduled[execution_plan.id]
     end
 

--- a/test/future_execution_test.rb
+++ b/test/future_execution_test.rb
@@ -105,11 +105,16 @@ module Dynflow
       end
 
       describe 'serializers' do
+        let(:save_and_load) do
+          ->(thing) { MultiJson.load(MultiJson.dump(thing)) }
+        end
+
         let(:simulated_use) do
           lambda do |serializer_class, input|
             serializer = serializer_class.new(input)
             serializer.perform_serialization!
-            serializer = serializer_class.new(nil, serializer.serialized_args)
+            serialized_args = save_and_load.call(serializer.serialized_args)
+            serializer = serializer_class.new(nil, serialized_args)
             serializer.perform_deserialization!
             serializer.args
           end

--- a/test/future_execution_test.rb
+++ b/test/future_execution_test.rb
@@ -10,6 +10,7 @@ module Dynflow
       describe 'action scheduling' do
 
         before do
+          @start_at = Time.now.utc + 180
           world.persistence.delete_scheduled_plans(:execution_plan_uuid => [])
         end
 
@@ -24,8 +25,11 @@ module Dynflow
         end
         let(:execution_plan) { plan.execution_plan }
 
+        it 'returns the progress as 0' do
+          execution_plan.progress.must_equal 0
+        end
+
         it 'schedules the action' do
-          @start_at = Time.now.utc + 180
           execution_plan.steps.count.must_equal 1
           plan.start_at.inspect.must_equal (@start_at).inspect
           history_names.call(execution_plan).must_equal ['schedule']
@@ -40,7 +44,6 @@ module Dynflow
         end
 
         it 'scheduled plans can be planned and executed' do
-          @start_at = Time.now.utc + 180
           execution_plan.state.must_equal :scheduled
           plan.plan
           execution_plan.state.must_equal :planned
@@ -55,7 +58,6 @@ module Dynflow
         end
 
         it 'expired plans can be failed' do
-          @start_at = Time.now.utc + 180
           plan.timeout
           execution_plan.state.must_equal :stopped
           execution_plan.result.must_equal :error

--- a/test/future_execution_test.rb
+++ b/test/future_execution_test.rb
@@ -31,7 +31,7 @@ module Dynflow
 
         it 'marks the plan as failed when issues in serialied phase' do
           world.persistence.delete_execution_plans({})
-          e = proc { world.schedule(::Support::DummyExample::DummyCustomScheuleSerializer, { :start_at => @start_at }, :fail) }.must_raise RuntimeError
+          e = proc { world.schedule(::Support::DummyExample::DummyCustomScheduleSerializer, { :start_at => @start_at }, :fail) }.must_raise RuntimeError
           e.message.must_equal 'Enforced serializer failure'
           plan = world.persistence.find_execution_plans(page: 0, per_page: 1, order_by: :ended_at, desc: true).first
           plan.state.must_equal :stopped

--- a/test/support/dummy_example.rb
+++ b/test/support/dummy_example.rb
@@ -19,7 +19,7 @@ module Support
       end
     end
 
-    class DummyCustomScheuleSerializer < Dynflow::Action
+    class DummyCustomScheduleSerializer < Dynflow::Action
       def schedule(schedule_options, *args)
         MySerializer.new(args)
       end

--- a/test/support/dummy_example.rb
+++ b/test/support/dummy_example.rb
@@ -6,6 +6,26 @@ module Support
       def run; end
     end
 
+    class MySerializer < Dynflow::Serializers::Abstract
+      def serialize
+        if args.first == :fail
+          raise 'Enforced serializer failure'
+        end
+        args
+      end
+
+      def deserialize
+        serialized_args
+      end
+    end
+
+    class DummyCustomScheuleSerializer < Dynflow::Action
+      def schedule(schedule_options, *args)
+        MySerializer.new(args)
+      end
+      def run; end
+    end
+
     class FailingDummy < Dynflow::Action
       def run; raise 'error'; end
     end

--- a/test/support/middleware_example.rb
+++ b/test/support/middleware_example.rb
@@ -80,7 +80,7 @@ module Support
 
       def schedule(schedule_options, *args)
         log 'schedule'
-        Dynflow::Serializers::Noop.new
+        Dynflow::Serializers::Noop.new(args)
       end
 
       def plan(input)

--- a/web/views/show.erb
+++ b/web/views/show.erb
@@ -11,7 +11,7 @@
   <%= h(@plan.result) %>
 </p>
 
-<% if @plan.state == :scheduled %>
+<% if @plan.state == :scheduled && @plan.schedule_record %>
   <p>
     <b>Start at:</b>
     <%= h(@plan.schedule_record.start_at) %>


### PR DESCRIPTION
They should be always 0.

Also, I hit an issue with a state, where the plan was in scheduled state, but
the scheduler record was not there: I updated the dynflow console to handle
this error better.