### PR TITLE
Remove active_support dependency

### DIFF
--- a/dynflow.gemspec
+++ b/dynflow.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency "activesupport"
   s.add_dependency "multi_json"
   s.add_dependency "apipie-params"
   s.add_dependency "algebrick", '~> 0.7.0'

--- a/lib/dynflow.rb
+++ b/lib/dynflow.rb
@@ -2,7 +2,6 @@ require 'apipie-params'
 require 'algebrick'
 require 'thread'
 require 'set'
-require 'active_support/core_ext/hash/indifferent_access'
 require 'base64'
 require 'concurrent'
 require 'concurrent-edge'
@@ -22,6 +21,7 @@ module Dynflow
   class Error < StandardError
   end
 
+  require 'dynflow/utils'
   require 'dynflow/round_robin'
   require 'dynflow/actor'
   require 'dynflow/errors'

--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -1,5 +1,3 @@
-require 'active_support/inflector'
-
 module Dynflow
   class Action < Serializable
 
@@ -127,13 +125,13 @@ module Dynflow
     def input=(hash)
       Type! hash, Hash
       phase! Plan
-      @input = hash.with_indifferent_access
+      @input = Utils.indifferent_hash(hash)
     end
 
     def output=(hash)
       Type! hash, Hash
       phase! Run
-      @output = hash.with_indifferent_access
+      @output = Utlis.indifferent_hash(hash)
     end
 
     def output

--- a/lib/dynflow/coordinator.rb
+++ b/lib/dynflow/coordinator.rb
@@ -41,7 +41,7 @@ module Dynflow
 
       def initialize(*args)
         @data ||= {}
-        @data = @data.merge(class: self.class.name).with_indifferent_access
+        @data = Utils.indifferent_hash(@data.merge(class: self.class.name))
       end
 
       def from_hash(hash)

--- a/lib/dynflow/execution_plan/output_reference.rb
+++ b/lib/dynflow/execution_plan/output_reference.rb
@@ -6,7 +6,7 @@ module Dynflow
     def self.dereference(object, persistence)
       case object
       when Hash
-        object.reduce(HashWithIndifferentAccess.new) do |h, (key, val)|
+        object.reduce(Utils.indifferent_hash({})) do |h, (key, val)|
           h.update(key => dereference(val, persistence))
         end
       when Array
@@ -25,7 +25,7 @@ module Dynflow
         if value[:class] == self.to_s
           new_from_hash(value)
         else
-          value.reduce(HashWithIndifferentAccess.new) do |h, (key, val)|
+          value.reduce(Utils.indifferent_hash({})) do |h, (key, val)|
             h.update(key => deserialize(val))
           end
         end

--- a/lib/dynflow/execution_plan/steps/error.rb
+++ b/lib/dynflow/execution_plan/steps/error.rb
@@ -32,7 +32,7 @@ module Dynflow
 
       def self.new_from_hash(hash)
         exception_class = begin
-                            hash[:exception_class].constantize
+                            Utils.constantize(hash[:exception_class])
                           rescue NameError
                             Errors::UnknownError.for_exception_class(hash[:exception_class])
                           end

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -243,7 +243,7 @@ module Dynflow
 
       def load(what, condition)
         table = table(what)
-        if (record = with_retry { table.first(condition.symbolize_keys) } )
+        if (record = with_retry { table.first(Utils.symbolize_keys(condition)) } )
           load_data(record)
         else
           raise KeyError, "searching: #{what} by: #{condition.inspect}"
@@ -251,11 +251,11 @@ module Dynflow
       end
 
       def load_data(record)
-        HashWithIndifferentAccess.new(MultiJson.load(record[:data]))
+        Utils.indifferent_hash(MultiJson.load(record[:data]))
       end
 
       def delete(what, condition)
-        table(what).where(condition.symbolize_keys).delete
+        table(what).where(Utils.symbolize_keys(condition)).delete
       end
 
       def extract_metadata(what, value)
@@ -312,7 +312,7 @@ module Dynflow
           raise ArgumentError, "unkown columns: #{unknown.inspect}"
         end
 
-        data_set.where filters.symbolize_keys
+        data_set.where Utils.symbolize_keys(filters)
       end
 
       def with_retry

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -260,7 +260,7 @@ module Dynflow
 
       def extract_metadata(what, value)
         meta_keys = META_DATA.fetch(what)
-        value         = value.with_indifferent_access
+        value         = Utils.indifferent_hash(value)
         meta_keys.inject({}) { |h, k| h.update k.to_sym => value[k] }
       end
 

--- a/lib/dynflow/scheduled_plan.rb
+++ b/lib/dynflow/scheduled_plan.rb
@@ -56,7 +56,7 @@ module Dynflow
 
     # @api private
     def self.new_from_hash(world, hash, *args)
-      serializer = hash[:args_serializer].constantize.new(nil, hash[:serialized_args])
+      serializer = Utils.constantize(hash[:args_serializer]).new(nil, hash[:serialized_args])
       self.new(world,
                hash[:execution_plan_uuid],
                string_to_time(hash[:start_at]),

--- a/lib/dynflow/serializable.rb
+++ b/lib/dynflow/serializable.rb
@@ -27,7 +27,7 @@ module Dynflow
     end
 
     def self.constantize(action_name)
-      action_name.constantize
+      Utils.constantize(action_name)
     end
 
     private_class_method :check_class_matching, :check_class_key_present

--- a/lib/dynflow/serializer.rb
+++ b/lib/dynflow/serializer.rb
@@ -19,7 +19,7 @@ module Dynflow
         end
 
         if (type_name = other[ARBITRARY_TYPE_KEY] || other[ARBITRARY_TYPE_KEY.to_s])
-          type = type_name.constantize rescue nil
+          type = Utils.constantize(type_name) rescue nil
           if type && type.respond_to?(:from_hash)
             return type.from_hash other
           end

--- a/lib/dynflow/testing/assertions.rb
+++ b/lib/dynflow/testing/assertions.rb
@@ -49,7 +49,7 @@ module Dynflow
         Match! action.phase, Action::Plan
         Match! action.state, :success
         action.execution_plan.planned_run_steps.must_include action
-        action.input.must_equal input.stringify_keys if input
+        action.input.must_equal Utils.stringify_keys(input) if input
         block.call action.input if block
       end
 

--- a/lib/dynflow/utils.rb
+++ b/lib/dynflow/utils.rb
@@ -1,0 +1,157 @@
+module Dynflow
+  module Utils
+
+    def self.indifferent_hash(hash)
+      if defined? ::HashWithIndifferentAccess
+        # the users already have it: lets give them what they are used to
+        ::HashWithIndifferentAccess.new(hash)
+      else
+        if hash.is_a? IndifferentHash
+          return hash
+        else
+          IndifferentHash.new(hash)
+        end
+      end
+    end
+
+    # Heaviliy inpired by ActiveSupport::HashWithIndifferentAccess,
+    # reasons we don't want to use the original implementation:
+    #   1. we don't want any core_ext extensions
+    #   2. some users are not happy about seeing the ActiveSupport as
+    #   our depednency
+    class IndifferentHash < Hash
+      def initialize(constructor = {})
+        if constructor.respond_to?(:to_hash)
+          super()
+          update(constructor)
+        else
+          super(constructor)
+        end
+      end
+
+      def default(key = nil)
+        if key.is_a?(Symbol) && include?(key = key.to_s)
+          self[key]
+        else
+          super
+        end
+      end
+
+      def self.[](*args)
+        new.merge!(Hash[*args])
+      end
+
+      alias_method :regular_writer, :[]= unless method_defined?(:regular_writer)
+      alias_method :regular_update, :update unless method_defined?(:regular_update)
+
+      def []=(key, value)
+        regular_writer(convert_key(key), convert_value(value, for: :assignment))
+      end
+
+      alias_method :store, :[]=
+
+      def update(other_hash)
+        if other_hash.is_a? IndifferentHash
+          super(other_hash)
+        else
+          other_hash.to_hash.each_pair do |key, value|
+            if block_given? && key?(key)
+              value = yield(convert_key(key), self[key], value)
+            end
+            regular_writer(convert_key(key), convert_value(value))
+          end
+          self
+        end
+      end
+
+      alias_method :merge!, :update
+
+      def key?(key)
+        super(convert_key(key))
+      end
+
+      alias_method :include?, :key?
+      alias_method :has_key?, :key?
+      alias_method :member?, :key?
+
+      def fetch(key, *extras)
+        super(convert_key(key), *extras)
+      end
+
+      def values_at(*indices)
+        indices.collect { |key| self[convert_key(key)] }
+      end
+
+      def dup
+        self.class.new(self).tap do |new_hash|
+          new_hash.default = default
+        end
+      end
+
+      def merge(hash, &block)
+        self.dup.update(hash, &block)
+      end
+
+      def reverse_merge(other_hash)
+        super(self.class.new_from_hash_copying_default(other_hash))
+      end
+
+      def reverse_merge!(other_hash)
+        replace(reverse_merge( other_hash ))
+      end
+
+      def replace(other_hash)
+        super(self.class.new_from_hash_copying_default(other_hash))
+      end
+
+      def delete(key)
+        super(convert_key(key))
+      end
+
+      def stringify_keys!; self end
+      def deep_stringify_keys!; self end
+      def stringify_keys; dup end
+      def deep_stringify_keys; dup end
+      def to_options!; self end
+
+      def select(*args, &block)
+        dup.tap { |hash| hash.select!(*args, &block) }
+      end
+
+      def reject(*args, &block)
+        dup.tap { |hash| hash.reject!(*args, &block) }
+      end
+
+      # Convert to a regular hash with string keys.
+      def to_hash
+        _new_hash = Hash.new(default)
+        each do |key, value|
+          _new_hash[key] = convert_value(value, for: :to_hash)
+        end
+        _new_hash
+      end
+
+      protected
+      def convert_key(key)
+        key.kind_of?(Symbol) ? key.to_s : key
+      end
+
+      def convert_value(value, options = {})
+        if value.is_a? Hash
+          if options[:for] == :to_hash
+            value.to_hash
+          else
+            Utils.indifferent_hash(value)
+          end
+        elsif value.is_a?(Array)
+          unless options[:for] == :assignment
+            value = value.dup
+          end
+          value.map! { |e| convert_value(e, options) }
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/dynflow/utils.rb
+++ b/lib/dynflow/utils.rb
@@ -1,6 +1,54 @@
 module Dynflow
   module Utils
 
+    def self.symbolize_keys(hash)
+      return hash.symbolize_keys if hash.respond_to?(:symbolize_keys)
+      hash.reduce({}) do |new_hash, (key, value)|
+        new_hash.update(key.to_sym => value)
+      end
+    end
+
+    def self.stringify_keys(hash)
+      return hash.stringify_keys if hash.respond_to?(:stringify_keys)
+      hash.reduce({}) do |new_hash, (key, value)|
+        new_hash.update(key.to_s => value)
+      end
+    end
+
+    # Inspired by ActiveSupport::Inflector
+    def self.constantize(string)
+      return string.constantize if string.respond_to?(:constantize)
+
+      names = string.split('::')
+
+      # Trigger a built-in NameError exception including the ill-formed constant in the message.
+      Object.const_get(string) if names.empty?
+
+      # Remove the first blank element in case of '::ClassName' notation.
+      names.shift if names.size > 1 && names.first.empty?
+
+      names.inject(Object) do |constant, name|
+        if constant == Object
+          constant.const_get(name)
+        else
+          candidate = constant.const_get(name)
+          next candidate if constant.const_defined?(name, false)
+          next candidate unless Object.const_defined?(name)
+
+          # Go down the ancestors to check if it is owned directly. The check
+          # stops when we reach Object or the end of ancestors tree.
+          constant = constant.ancestors.inject do |const, ancestor|
+            break const    if ancestor == Object
+            break ancestor if ancestor.const_defined?(name, false)
+            const
+          end
+
+          # owner is in Object, so raise
+          constant.const_get(name, false)
+        end
+      end
+    end
+
     def self.indifferent_hash(hash)
       if defined? ::HashWithIndifferentAccess
         # the users already have it: lets give them what they are used to

--- a/lib/dynflow/web/console_helpers.rb
+++ b/lib/dynflow/web/console_helpers.rb
@@ -133,7 +133,7 @@ module Dynflow
       end
 
       def updated_url(new_params)
-        url(request.path_info + "?" + Rack::Utils.build_nested_query(params.merge(new_params.stringify_keys)))
+        url(request.path_info + "?" + Rack::Utils.build_nested_query(params.merge(Utils.stringify_keys(new_params))))
       end
 
       def paginated_url(delta)

--- a/lib/dynflow/web/filtering_helpers.rb
+++ b/lib/dynflow/web/filtering_helpers.rb
@@ -24,7 +24,7 @@ module Dynflow
         else
           filters = {}
         end
-        @filtering_options = { filters: filters }.with_indifferent_access
+        @filtering_options = Utils.indifferent_hash(filters: filters)
         return @filtering_options
       end
 

--- a/lib/dynflow/web/filtering_helpers.rb
+++ b/lib/dynflow/web/filtering_helpers.rb
@@ -20,7 +20,7 @@ module Dynflow
           filters = params[:filters]
         elsif supported_filter?('state')
           excluded_states = show_all ? [] : ['stopped']
-          filters = { 'state' => ExecutionPlan.states.map(&:to_s) - excluded_states }          
+          filters = { 'state' => ExecutionPlan.states.map(&:to_s) - excluded_states }
         else
           filters = {}
         end
@@ -29,7 +29,7 @@ module Dynflow
       end
 
       def find_execution_plans_options(show_all = false)
-        options = HashWithIndifferentAccess.new
+        options = Utils.indifferent_hash({})
         options.merge!(filtering_options(show_all))
         options.merge!(pagination_options)
         options.merge!(ordering_options)

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -81,7 +81,7 @@ module Dynflow
       # TODO what happens with newly loaded classes
       @action_classes = @action_classes.map do |klass|
         begin
-          klass.to_s.constantize
+          Utils.constantize(klass.to_s)
         rescue NameError
           nil # ignore missing classes
         end
@@ -352,7 +352,7 @@ module Dynflow
           action_classes.each_with_object(Hash.new { |h, k| h[k] = [] }) do |klass, index|
             next unless klass.subscribe
             Array(klass.subscribe).each do |subscribed_class|
-              index[subscribed_class.to_s.constantize] << klass
+              index[Utils.constantize(subscribed_class.to_s)] << klass
             end
           end.tap { |o| o.freeze }
     end

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -148,7 +148,7 @@ module Dynflow
             prepare_action('plan1')
             loaded_action = adapter.load_action('plan1', action_id)
             loaded_action[:id].must_equal action_id
-            loaded_action.must_equal(action_data.stringify_keys)
+            loaded_action.must_equal(Utils.stringify_keys(action_data))
 
             adapter.save_action('plan1', action_id, nil)
             -> { adapter.load_action('plan1', action_id) }.must_raise KeyError
@@ -164,7 +164,7 @@ module Dynflow
             prepare_step('plan1')
             loaded_step = adapter.load_step('plan1', step_id)
             loaded_step[:id].must_equal step_id
-            loaded_step.must_equal(step_data.stringify_keys)
+            loaded_step.must_equal(Utils.stringify_keys(step_data))
           end
         end
       end

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -189,7 +189,7 @@ module Dynflow
         it "supports connector's needs for exchaning envelopes" do
           client_world_id   = '5678'
           executor_world_id = '1234'
-          envelope_hash = ->(envelope) { Dynflow.serializer.dump(envelope).with_indifferent_access }
+          envelope_hash = ->(envelope) { Dynflow::Utils.indifferent_hash(Dynflow.serializer.dump(envelope)) }
           executor_envelope = envelope_hash.call(Dispatcher::Envelope[123, client_world_id, executor_world_id, Dispatcher::Execution['111']])
           client_envelope   = envelope_hash.call(Dispatcher::Envelope[123, executor_world_id, client_world_id, Dispatcher::Accepted])
           envelopes         = [client_envelope, executor_envelope]

--- a/test/testing_test.rb
+++ b/test/testing_test.rb
@@ -118,7 +118,7 @@ module Dynflow
         let(:runned_action) { run_action planned_action }
 
         it 'plans' do
-          planned_action.input.must_equal input.stringify_keys
+          planned_action.input.must_equal Utils.stringify_keys(input)
           assert_run_phase planned_action, { commit: "sha", reviewer: "name", result: true}
           refute_finalize_phase planned_action
 


### PR DESCRIPTION
Don't force the users to use active support extensions, unless they want it on
their own. Dynflow now can operate without active support in place. On the other hand,
for backward compatibility, as well as user convenience (if the HashWithIndifferent
access is there, they probably are already used to it), if the active support is present,
use it's features instead of the alternative implementation.