### PR TITLE
[suggestion] Changes interface of serializers

### DIFF
--- a/lib/dynflow/serializers/abstract.rb
+++ b/lib/dynflow/serializers/abstract.rb
@@ -20,19 +20,19 @@ module Dynflow
       end
 
       def perform_serialization!
-        @serialized_args = serialize
+        @serialized_args = args.map { |arg| serialize arg }
       end
 
       def perform_deserialization!
         raise "@serialized_args not set" if @serialized_args.nil?
-        @args = deserialize
+        @args = serialized_args.map { |arg| deserialize arg }
       end
 
-      def serialize
+      def serialize(arg)
         raise NotImplementedError
       end
 
-      def deserialize
+      def deserialize(arg)
         raise NotImplementedError
       end
 

--- a/lib/dynflow/serializers/noop.rb
+++ b/lib/dynflow/serializers/noop.rb
@@ -2,12 +2,12 @@ module Dynflow
   module Serializers
     class Noop < Abstract
 
-      def serialize
-        args
+      def serialize(arg)
+        arg
       end
 
-      def deserialize
-        serialized_args
+      def deserialize(arg)
+        arg
       end
 
     end

--- a/test/support/dummy_example.rb
+++ b/test/support/dummy_example.rb
@@ -6,16 +6,10 @@ module Support
       def run; end
     end
 
-    class MySerializer < Dynflow::Serializers::Abstract
-      def serialize
-        if args.first == :fail
-          raise 'Enforced serializer failure'
-        end
-        args
-      end
-
-      def deserialize
-        serialized_args
+    class MySerializer < Dynflow::Serializers::Noop
+      def serialize(arg)
+        raise 'Enforced serializer failure' if arg == :fail
+        super arg
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,9 @@
 require 'bundler/setup'
+require 'minitest/reporters'
 require 'minitest/autorun'
 require 'minitest/spec'
 
-if ENV['RM_INFO']
-  require 'minitest/reporters'
-  MiniTest::Reporters.use!
-end
+MiniTest::Reporters.use! if ENV['RM_INFO']
 
 load_path = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH << load_path unless $LOAD_PATH.include? load_path


### PR DESCRIPTION
With the current serializers interface it is almost impossible to extend what kind of object can existing serializer (de)serialize without reimplementing the whole serializer. With this patch one could do:
```ruby
class SerializerOne < Dynflow::Serializers::Noop
  def serialize(arg)
    arg.is_a?(Class) ? { :is_a => :class, :class_name => arg.to_s } : super(arg) # Serializers::Noop#serialize
  end

  def deserialize(arg)
    arg[:is_a] == :class ? arg[:class_name].constantize : super(arg) # Serializers::Noop#deserialize
  end
end

class SerializerTwo < SerializerOne
  def serialize(arg)
    arg.is_a?(Time) ? { :is_a => :time, :as_f => arg.to_f } : super(arg) # SerializerOne#serialize
  end

  def deserialize(arg)
    arg[:is_a] == :time ? Time.at(arg[:as_f]) : super(arg) # SerializerOne#deserialize
  end
end
```
to make SerializerTwo able to serialize class names and time information.
