### PR TITLE
Ensure the locks are released when world is being deleted

### DIFF
--- a/lib/dynflow/config.rb
+++ b/lib/dynflow/config.rb
@@ -77,7 +77,7 @@ module Dynflow
       !!config.executor
     end
 
-    config_attr :validity_check_timeout, Fixnum do
+    config_attr :validity_check_timeout, Numeric do
       5
     end
 

--- a/lib/dynflow/coordinator.rb
+++ b/lib/dynflow/coordinator.rb
@@ -277,6 +277,7 @@ module Dynflow
 
     def delete_world(world)
       Type! world, Coordinator::ClientWorld, Coordinator::ExecutorWorld
+      release_by_owner("world:#{world.id}")
       delete_record(world)
     end
 

--- a/lib/dynflow/coordinator.rb
+++ b/lib/dynflow/coordinator.rb
@@ -155,6 +155,17 @@ module Dynflow
         @data[:world_id]
       end
 
+      def self.valid_owner_ids(coordinator)
+        coordinator.find_worlds.map { |w| "world:#{w.id}" }
+      end
+
+      def self.valid_classes
+        @valid_classes ||= []
+      end
+
+      def self.inherited(klass)
+        valid_classes << klass
+      end
     end
 
     class DelayedExecutorLock < LockByWorld
@@ -285,6 +296,25 @@ module Dynflow
       Type! world, Coordinator::ExecutorWorld
       world.active = false
       update_record(world)
+    end
+
+    def clean_orphaned_locks
+      cleanup_classes = [LockByWorld]
+      ret = []
+      cleanup_classes.each do |cleanup_class|
+        valid_owner_ids = cleanup_class.valid_owner_ids(self)
+        valid_classes = cleanup_class.valid_classes.map(&:name)
+        orphaned_locks = find_locks(class: valid_classes, exclude_owner_id: valid_owner_ids)
+        # reloading the valid owner ids to avoid race conditions
+        valid_owner_ids = cleanup_class.valid_owner_ids(self)
+        orphaned_locks.each do |lock|
+          unless valid_owner_ids.include?(lock.owner_id)
+            release(lock)
+            ret << lock
+          end
+        end
+      end
+      return ret
     end
   end
 end

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -177,7 +177,12 @@ module Dynflow
       def find_coordinator_records(options)
         coordinator_feature!
         options = options.dup
-        data_set = filter(:coordinator_record, table(:coordinator_record), options[:filters])
+        filters = (options[:filters] || {}).dup
+        exclude_owner_id = filters.delete(:exclude_owner_id)
+        data_set = filter(:coordinator_record, table(:coordinator_record), filters)
+        if exclude_owner_id
+          data_set = data_set.exclude(:owner_id => exclude_owner_id)
+        end
         data_set.map { |record| load_data(record) }
       end
 

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -229,7 +229,6 @@ module Dynflow
               clock.ask(:terminate!).wait
             end
 
-            coordinator.release_by_owner("world:#{registered_world.id}")
             coordinator.delete_world(registered_world)
             true
           rescue => e

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -34,7 +34,10 @@ module Dynflow
         @executor_dispatcher = spawn_and_wait(Dispatcher::ExecutorDispatcher, "executor-dispatcher", self)
         executor.initialized.wait
       end
-      self.worlds_validity_check if auto_validity_check
+      if auto_validity_check
+        self.worlds_validity_check
+        self.locks_validity_check
+      end
       @delayed_executor         = try_spawn_delayed_executor(config_for_world)
       @meta                     = config_for_world.meta
       @meta['delayed_executor'] = true if @delayed_executor
@@ -324,6 +327,16 @@ module Dynflow
       end
 
       return results
+    end
+
+    def locks_validity_check
+      orphaned_locks = coordinator.clean_orphaned_locks
+
+      unless orphaned_locks.empty?
+        logger.error "invalid coordinator locks found and invalidated: #{orphaned_locks.inspect}"
+      end
+
+      return orphaned_locks
     end
 
     # executes plans that are planned/paused and haven't reported any error yet (usually when no executor

--- a/test/abnormal_states_recovery_test.rb
+++ b/test/abnormal_states_recovery_test.rb
@@ -35,8 +35,8 @@ module Dynflow
       let(:persistence_adapter) { WorldFactory.persistence_adapter }
       let(:shared_connector) { Connectors::Direct.new }
       let(:connector) { Proc.new { |world| shared_connector.start_listening(world); shared_connector } }
-      let(:executor_world) { create_world(true) }
-      let(:executor_world_2) { create_world(true) }
+      let(:executor_world) { create_world(true) { |config| config.auto_validity_check = true } }
+      let(:executor_world_2) { create_world(true) { |config| config.auto_validity_check = true } }
       let(:client_world) { create_world(false) }
       let(:client_world_2) { create_world(false) }
 
@@ -176,8 +176,11 @@ module Dynflow
           end
 
           it 'by default, the auto_validity_check is enabled only for executor words' do
-            create_world(false).auto_validity_check.must_equal false
-            create_world(true).auto_validity_check.must_equal true
+            client_world_config = Config::ForWorld.new(Config.new.tap { |c| c.executor = false }, create_world )
+            client_world_config.auto_validity_check.must_equal false
+
+            executor_world_config = Config::ForWorld.new(Config.new.tap { |c| c.executor = lambda { |w, _| Executors::Parallel.new(w) } }, create_world )
+            executor_world_config.auto_validity_check.must_equal true
           end
 
           it 'reports the validation status' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,6 +88,7 @@ module WorldFactory
     config.coordinator_adapter = coordinator_adapter
     config.delayed_executor    = nil
     config.auto_rescue         = false
+    config.auto_validity_check = false
     config.exit_on_terminate   = false
     config.auto_execute        = false
     config.auto_terminate      = false
@@ -138,13 +139,14 @@ module TestHelpers
   # allows to create the world inside the tests, using the `connector`
   # and `persistence adapter` from the test context: usefull to create
   # multi-world topology for a signle test
-  def create_world(with_executor = true)
+  def create_world(with_executor = true, &block)
     WorldFactory.create_world do |config|
       config.connector = connector
       config.persistence_adapter = persistence_adapter
       unless with_executor
         config.executor = false
       end
+      block.call(config) if block
     end
   end
 


### PR DESCRIPTION
Otherwise, invalidated worlds still keep the locks after being deleted.

How to reproduce:

1. start first world: it should get the delayed executor flag. 2. invalidate
the world 3. start another world

Expected: the new world is flagged as delayed executor Before fix: the world
is not delayed executor, because an old DelayedExecutorLock is still acquired
for the old world.