### PR TITLE
We can add links to the navbar from outside of the dynflow

### DIFF
--- a/lib/dynflow/web.rb
+++ b/lib/dynflow/web.rb
@@ -18,6 +18,7 @@ module Dynflow
       File.join(web_dir, sub_dir)
     end
 
+    require 'dynflow/web/navbar_items_helper'
     require 'dynflow/web/filtering_helpers'
     require 'dynflow/web/world_helpers'
     require 'dynflow/web/console_helpers'

--- a/lib/dynflow/web/console.rb
+++ b/lib/dynflow/web/console.rb
@@ -11,6 +11,7 @@ module Dynflow
       helpers Web::FilteringHelpers
       helpers Web::WorldHelpers
       helpers Web::ConsoleHelpers
+      helpers Web::NavbarItemsHelper
 
       get('/') do
         options = find_execution_plans_options

--- a/lib/dynflow/web/navbar_items_helper.rb
+++ b/lib/dynflow/web/navbar_items_helper.rb
@@ -1,0 +1,16 @@
+module Dynflow
+  module Web
+    module NavbarItemsHelper
+      module Link
+
+        def self.link_back(url)
+          @@link_back ||= url
+        end
+      end
+
+      def back
+        Link.link_back request.referrer
+      end
+    end
+  end
+end

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -36,6 +36,9 @@
             <ul class="nav navbar-nav">
               <li><a href="<%= url '/' %>">Execution plans</a></li>
               <li><a href="<%= url '/status' %>">Status</a></li>
+              <% if back %>
+                  <li><a href="<%= back %>">Back to Foreman</a></li>
+              <% end %>
             </ul>
             <ul class="nav navbar-nav navbar-right">
             </ul>


### PR DESCRIPTION
It allows us to add links to the main navbar from outside of the dynflow (when dynflow console is mounted in a Rails application, for example). The parent application where console is mounted is beyond reach of console's routing, ~~so there is some url manipulation going on.~~
~~See [this](https://github.com/theforeman/foreman-tasks/pull/152) for usage.~~
