### PR TITLE
Relax the concurrent ruby dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language:
   - ruby
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :concurrent_ruby_ext do
-  gem 'concurrent-ruby-ext', '~> 1.0.0'
+  gem 'concurrent-ruby-ext', '~> 1.0'
 end
 
 group :pry do

--- a/dynflow.gemspec
+++ b/dynflow.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   s.add_dependency "multi_json"
   s.add_dependency "apipie-params"
   s.add_dependency "algebrick", '~> 0.7.0'
-  s.add_dependency "concurrent-ruby", '~> 1.0.0'
-  s.add_dependency "concurrent-ruby-edge", '~> 0.2.0'
+  s.add_dependency "concurrent-ruby", '~> 1.0'
+  s.add_dependency "concurrent-ruby-edge", '~> 0.2'
   s.add_dependency "sequel"
 
   s.add_development_dependency "rack-test"


### PR DESCRIPTION
concurrent-ruby team has always been nice to us in terms of backward
compatibility: let's rely on sem-ver for now and relax the version requirements
a bit