### PR TITLE
Fix thread-safety issue with sequel iteration

### DIFF
--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -183,7 +183,7 @@ module Dynflow
         if exclude_owner_id
           data_set = data_set.exclude(:owner_id => exclude_owner_id)
         end
-        data_set.map { |record| load_data(record) }
+        data_set.all.map { |record| load_data(record) }
       end
 
       def to_hash


### PR DESCRIPTION
The dataset.each is not thread-safe, as described in documentation for the
method

  https://github.com/jeremyevans/sequel/blob/4.20.0/lib/sequel/dataset/actions.rb#L126-L142

I suspect this to cause intermittent segmentation faults when under heaver
load.