### PR TITLE
Fix consistency check for stopped tasks

### DIFF
--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -291,7 +291,7 @@ module Dynflow
         end
       end
 
-      plan.update_state(:paused) unless plan.state == :paused
+      plan.update_state(:paused) unless [:paused, :stopped].include?(plan.state)
       plan.save
       coordinator.release(execution_lock)
       unless plan.error?


### PR DESCRIPTION
In occasional cases, it might happen that invalidated world got
marked as stopped before, while we try set it as paused, which
is not a valid transition.