### PR TITLE
Don't use sequel map method

### DIFF
--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -55,7 +55,7 @@ module Dynflow
                                 paginate(table(:execution_plan), options),
                                 options),
                           options[:filters])
-        data_set.map { |record| load_data(record) }
+        data_set.all.map { |record| load_data(record) }
       end
 
       def delete_execution_plans(filters, batch_size = 1000)


### PR DESCRIPTION
The Sequel's map method on dataset is not thread sefe, which might
occasionally lead to stack consistency issues. We already addreseed
similar case in 1510982b3d2b641ee4248cf6aa0ad9bd5392f828.

While it seemed it was the only place it might cause troubles,
similar thing could happen with auto-execute functionality,
when many tasks were pending. I've converted the rest of map
calls that return the result of map outside of the adapter to
make sure they are thread safe.