### PR TITLE
Set logger before validating world

### DIFF
--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -13,8 +13,8 @@ module Dynflow
       @id                     = SecureRandom.uuid
       @clock                  = spawn_and_wait(Clock, 'clock')
       config_for_world        = Config::ForWorld.new(config, self)
-      config_for_world.validate
       @logger_adapter         = config_for_world.logger_adapter
+      config_for_world.validate
       @transaction_adapter    = config_for_world.transaction_adapter
       @persistence            = Persistence.new(self, config_for_world.persistence_adapter)
       @coordinator            = Coordinator.new(config_for_world.coordinator_adapter)


### PR DESCRIPTION
Currently when a Rails application initializes a new world, Dynflow may
use the logger from that world on the validation. However, that fails
because the logger hasn't been defined until the config for the wolrd
has been validated.

See how Config#validate calls 'config_for_world.world.logger'. That will
in turn call World#logger, which calls `logger_adapter` and fails
because the logger has not been set yet.

This commit ensure that there is a logger available every time we
initialize a world, therefore being able to validate the config on Rails
apps instead of failing

----------------------

I saw this failure just by using ForemanTasks with Dynflow. When I run any Rake task in Foreman, I get 'NoMethodError: undefined method `dynflow_logger' for nil:NilClass'  because the logger_adapter hasn't been defined as I explain above