### PR TITLE
Fixes #17177 - Handle invalidation with plans are missing

### DIFF
--- a/test/abnormal_states_recovery_test.rb
+++ b/test/abnormal_states_recovery_test.rb
@@ -85,6 +85,16 @@ module Dynflow
                               "unlock world-invalidation:#{executor_world.id}"]
             client_world.coordinator.adapter.lock_log.must_equal(expected_locks)
           end
+
+          it "handles missing execution plans" do
+            lock = Coordinator::ExecutionLock.new(executor_world, "missing", nil, nil)
+            executor_world.coordinator.acquire(lock)
+            client_world.invalidate(executor_world.registered_world)
+            expected_locks = ["lock world-invalidation:#{executor_world.id}",
+                              "unlock execution-plan:missing",
+                              "unlock world-invalidation:#{executor_world.id}"]
+            client_world.coordinator.adapter.lock_log.must_equal(expected_locks)
+          end
         end
       end
 


### PR DESCRIPTION
Under some circumstances (such as manually deleting execution plans in
database), it might happen that the execution plan we try to invalidate
is no longer present. This patch allows to recover from this kind of
situations.