### PR TITLE
When invalidating, pause only running steps

### DIFF
--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -291,7 +291,7 @@ module Dynflow
         end
       end
 
-      plan.update_state(:paused) unless [:paused, :stopped].include?(plan.state)
+      plan.update_state(:paused) if plan.state == :running
       plan.save
       coordinator.release(execution_lock)
       unless plan.error?


### PR DESCRIPTION
We hit an issue where we needed to invalidate a plan that was in planned
state. This lead to
 "invalid state transition planned >> paused in <Dynflow::ExecutionPlan"

It turns out the only valid transition to paused state is from running,
so switching the condition to just do it then.