### PR TITLE
Fixes #17212 - show plan timing info

### DIFF
--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -133,6 +133,18 @@ module Dynflow
       end
     end
 
+    def plan_steps
+      steps_of_type(Dynflow::ExecutionPlan::Steps::PlanStep)
+    end
+
+    def run_steps
+      steps_of_type(Dynflow::ExecutionPlan::Steps::RunStep)
+    end
+
+    def finalize_steps
+      steps_of_type(Dynflow::ExecutionPlan::Steps::FinalizeStep)
+    end
+
     def failed_steps
       steps_in_state(:error)
     end
@@ -263,6 +275,11 @@ module Dynflow
     end
 
     # @api private
+
+    def steps_of_type(type)
+      steps.values.find_all { |step| step.is_a?(type) }
+    end
+
     def current_run_flow
       @run_flow_stack.last
     end

--- a/lib/dynflow/throttle_limiter.rb
+++ b/lib/dynflow/throttle_limiter.rb
@@ -100,7 +100,7 @@ module Dynflow
 
       def cancel_plan_id(plan_id, reason)
         plan = @world.persistence.load_execution_plan(plan_id)
-        steps = plan.steps.values.select { |step| step.is_a?(::Dynflow::ExecutionPlan::Steps::RunStep) }
+        steps = plan.run_steps
         steps.each do |step|
           step.state = :error
           step.error = ::Dynflow::ExecutionPlan::Steps::Error.new(reason)

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -113,9 +113,8 @@ module Dynflow
             TestPause.when_paused do
               plan = world.persistence.load_execution_plan(execution_plan.id)
               plan.state.must_equal :running
-              triage = plan.steps.values.find do |s|
-                s.is_a?(Dynflow::ExecutionPlan::Steps::RunStep) &&
-                    s.action_class == Support::CodeWorkflowExample::Triage
+              triage = plan.run_steps.find do |s|
+                s.action_class == Support::CodeWorkflowExample::Triage
               end
               triage.state.must_equal :running
               world.persistence.
@@ -204,10 +203,7 @@ module Dynflow
             it 'fails' do
               assert_equal :error, result.result
               assert_equal :paused, result.state
-              assert_equal :error,
-                           result.steps.values.
-                               find { |s| s.is_a? Dynflow::ExecutionPlan::Steps::RunStep }.
-                               state
+              assert_equal :error, result.run_steps.first.state
             end
           end
 
@@ -292,14 +288,12 @@ module Dynflow
             specify do
               assert_equal :paused, result.state
               assert_equal :error, result.result
-              assert_equal :error, result.steps.values.
-                  find { |s| s.is_a? Dynflow::ExecutionPlan::Steps::RunStep }.state
+              assert_equal :error, result.run_steps.first.state
 
               ep = world.execute(result.id).value
               assert_equal :stopped, ep.state
               assert_equal :success, ep.result
-              assert_equal :success, ep.steps.values.
-                  find { |s| s.is_a? Dynflow::ExecutionPlan::Steps::RunStep }.state
+              assert_equal :success, ep.run_steps.first.state
             end
           end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -332,10 +332,7 @@ module PlanAssertions
   end
 
   def assert_planning_success(execution_plan)
-    plan_steps = execution_plan.steps.values.find_all do |step|
-      step.is_a? Dynflow::ExecutionPlan::Steps::PlanStep
-    end
-    plan_steps.all? { |plan_step| plan_step.state.must_equal :success, plan_step.error }
+    execution_plan.plan_steps.all? { |plan_step| plan_step.state.must_equal :success, plan_step.error }
   end
 
   def assert_run_flow(expected, execution_plan)

--- a/web/views/plan_step.erb
+++ b/web/views/plan_step.erb
@@ -4,6 +4,8 @@
       <span class="label label-<%= step_css_class(step) %>"><%= h("#{step.action_class}") %></span>
     </p>
     <div class="action">
+      <p><b>Started at:</b> <%= h(step.started_at) %></p>
+      <p><b>Ended at:</b> <%= h(step.ended_at) %> (duration <%= duration_to_s(step.real_time) %>)</p>
       <% action = step.action @plan %>
       <%= show_action_data("Input:", action.input) %>
       <%= step_error(step) %>


### PR DESCRIPTION
Includes also a small refactoring which makes it easier to access
plan/run/finalize steps of execution plan