### PR TITLE
Fixes #17175 - Added watcher that can terminate a world

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 
 group :pry do
   gem 'pry'
+  gem 'pry-byebug'
 end
 
 group :postgresql do
@@ -28,4 +29,8 @@ end
 
 group :lint do
   gem 'rubocop', '0.39.0'
+end
+
+group :memory_watcher do
+  gem 'get_process_mem'
 end

--- a/examples/memory_limit_watcher.rb
+++ b/examples/memory_limit_watcher.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+require_relative 'example_helper'
+
+example_description = <<DESC
+  Memory limit watcher Example
+  ===========================
+
+In this example we are setting a watcher that will terminate our world object
+when process memory consumption exceeds a limit that will be set.
+
+
+DESC
+
+module MemorylimiterExample
+  class SampleAction < Dynflow::Action
+    def plan(memory_to_use)
+      plan_self(number: memory_to_use)
+    end
+
+    def run
+      array = Array.new(input[:number].to_i)
+      puts "[action] allocated #{input[:number]} cells"
+    end
+  end
+end
+
+if $0 == __FILE__
+  puts example_description
+
+  world = ExampleHelper.create_world do |config|
+    config.exit_on_terminate = false
+  end
+
+  world.terminated.on_completion do
+    puts '[world] The world has been terminated'
+  end
+
+  require 'get_process_mem'
+  memory_info_provider = GetProcessMem.new
+  puts '[info] Preparing memory watcher: '
+  require 'dynflow/watchers/memory_consumption_watcher'
+  puts "[info] now the process consumes #{memory_info_provider.bytes} bytes."
+  limit = memory_info_provider.bytes + 500_000
+  puts "[info] Setting memory limit to #{limit} bytes"
+  watcher = Dynflow::Watchers::MemoryConsumptionWatcher.new(world, limit, polling_interval: 1)
+  puts '[info] Small action: '
+  world.trigger(MemorylimiterExample::SampleAction, 10)
+  sleep 2
+  puts "[info] now the process consumes #{memory_info_provider.bytes} bytes."
+  puts '[info] Big action: '
+  world.trigger(MemorylimiterExample::SampleAction, 500_000)
+  sleep 2
+  puts "[info] now the process consumes #{memory_info_provider.bytes} bytes."
+  puts '[info] Small action again - will not execute, the world is not accepting requests'
+  world.trigger(MemorylimiterExample::SampleAction, 500_000)
+  sleep 2
+  puts 'Done'
+end

--- a/lib/dynflow/testing/in_thread_world.rb
+++ b/lib/dynflow/testing/in_thread_world.rb
@@ -52,6 +52,7 @@ module Dynflow
         @executor.terminate
         coordinator.delete_world(registered_world)
         future.success true
+        @terminated.complete
       rescue => e
         future.fail e
       end

--- a/lib/dynflow/watchers/memory_consumption_watcher.rb
+++ b/lib/dynflow/watchers/memory_consumption_watcher.rb
@@ -1,0 +1,32 @@
+require 'get_process_mem'
+
+module Dynflow
+  module Watchers
+    class MemoryConsumptionWatcher
+
+      attr_reader :memory_limit, :world
+
+      def initialize(world, memory_limit, options)
+        @memory_limit = memory_limit
+        @world = world
+        @polling_interval = options[:polling_interval] || 60
+        @memory_info_provider = options[:memory_info_provider] || GetProcessMem.new
+        set_timer options[:initial_wait] || @polling_interval
+      end
+
+      def check_memory_state
+        if @memory_info_provider.bytes > @memory_limit
+          # terminate the world and stop polling
+          world.terminate
+        else
+          # memory is under the limit - keep waiting
+          set_timer
+        end
+      end
+
+      def set_timer(interval = @polling_interval)
+        @world.clock.ping(self, interval, nil, :check_memory_state)
+      end
+    end
+  end
+end

--- a/test/memory_cosumption_watcher_test.rb
+++ b/test/memory_cosumption_watcher_test.rb
@@ -1,0 +1,87 @@
+require_relative 'test_helper'
+require 'fileutils'
+require 'dynflow/watchers/memory_consumption_watcher'
+
+module Dynflow
+  module MemoryConsumptionWatcherTest
+    describe ::Dynflow::Watchers::MemoryConsumptionWatcher do
+      let(:world) { Minitest::Mock.new('world') }
+      describe 'initialization' do
+        it 'starts a timer on the world' do
+          clock = Minitest::Mock.new('clock')
+          world.expect(:clock, clock)
+          init_interval = 1000
+          clock.expect(:ping, true) do |clock_who, clock_when, _|
+            clock_when.must_equal init_interval
+          end
+
+          Dynflow::Watchers::MemoryConsumptionWatcher.new world, 1, initial_wait: init_interval
+
+          clock.verify
+        end
+      end
+
+      describe 'polling' do
+        let(:memory_info_provider) { Minitest::Mock.new('memory_info_provider') }
+        it 'continues to poll, if memory limit is not exceeded' do
+          clock = Minitest::Mock.new('clock')
+          # define method clock
+          world.expect(:clock, clock)
+          init_interval = 1000
+          polling_interval = 2000
+          clock.expect(:ping, true) do |clock_who, clock_when, _|
+            clock_when.must_equal init_interval
+            true
+          end
+          clock.expect(:ping, true) do |clock_who, clock_when, _|
+            clock_when.must_equal polling_interval
+            true
+          end
+          memory_info_provider.expect(:bytes, 0)
+
+          # stub the clock method to always return our mock clock
+          world.stub(:clock, clock) do
+            watcher = Dynflow::Watchers::MemoryConsumptionWatcher.new(
+              world,
+              1,
+              initial_wait: init_interval,
+              memory_info_provider: memory_info_provider,
+              polling_interval: polling_interval
+            )
+            watcher.check_memory_state
+          end
+
+          clock.verify
+          memory_info_provider.verify
+        end
+
+        it 'terminates the world, if memory limit reached' do
+          clock = Minitest::Mock.new('clock')
+          # define method clock
+          world.expect(:clock, clock)
+          world.expect(:terminate, true)
+
+          init_interval = 1000
+          clock.expect(:ping, true) do |clock_who, clock_when, _|
+            clock_when.must_equal init_interval
+            true
+          end
+          memory_info_provider.expect(:bytes, 10)
+
+          # stub the clock method to always return our mock clock
+          watcher = Dynflow::Watchers::MemoryConsumptionWatcher.new(
+            world,
+            1,
+            initial_wait: init_interval,
+            memory_info_provider: memory_info_provider
+          )
+          watcher.check_memory_state
+
+          clock.verify
+          memory_info_provider.verify
+          world.verify
+        end
+      end
+    end
+  end
+end

--- a/test/testing_test.rb
+++ b/test/testing_test.rb
@@ -168,7 +168,7 @@ module Dynflow
 
     describe "in thread executor" do
       let :world do
-        Dynflow::Testing::InThreadWorld.instance
+        WorldFactory.create_world(Dynflow::Testing::InThreadWorld)
       end
 
       let :issues_data do

--- a/test/world_test.rb
+++ b/test/world_test.rb
@@ -18,6 +18,18 @@ module Dynflow
           registered_world.meta.must_equal('fast' => true)
         end
       end
+
+      describe '#terminate' do
+        it 'fires an event after termination' do
+          terminated_event = world.terminated
+          terminated_event.completed?.must_equal false
+          world.terminate
+          # wait for termination process to finish, but don't block
+          # the test from running.
+          terminated_event.wait(10)
+          terminated_event.completed?.must_equal true
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This watcher polls the memory size of the process it runs in and terminates the world if memory limit is exceeded.
This commit also adds `terminated` event to `World` class, so anyone can add a listener that will perform tasks after a world is terminated.