### PR TITLE
Fixes #18206 - Redispatch invalid requests only when executor exists

### DIFF
--- a/dynflow.gemspec
+++ b/dynflow.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "multi_json"
   s.add_dependency "apipie-params"
-  s.add_dependency "algebrick", '~> 0.7.0'
+  s.add_dependency "algebrick", '>= 0.7.0', '< 0.7.4'
   s.add_dependency "concurrent-ruby", '~> 1.0'
   s.add_dependency "concurrent-ruby-edge", '~> 0.2.3'
   s.add_dependency "sequel"

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -300,7 +300,9 @@ module Dynflow
       plan.update_state(:paused) if plan.state == :running
       plan.save
       coordinator.release(execution_lock)
-      unless plan.error?
+
+      available_executors = coordinator.find_worlds(true)
+      if available_executors.any? && !plan.error?
         client_dispatcher.tell([:dispatch_request,
                                 Dispatcher::Execution[execution_lock.execution_plan_id],
                                 execution_lock.client_world_id,


### PR DESCRIPTION
Minimal reproducer for this issue:
1. Have Foreman/Satellite with at least one Dynflow task running.    (Actions::Candlepin::ListenOnCandlepinEvents in Katello/Satellite is a good candidate)
2. kill dynflow executor while the task is running: pkill -9 -f dynflow_executor
3. foreman-rake db:migrate

You should see errors in the output
```
E, [2017-01-24T03:00:53.032499 #9544] ERROR -- /client-dispatcher: No executor available (Dynflow::Error)
```

With this patch the migration should proceed with no errors.