### PR TITLE
Batch planning of sub tasks

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -21,6 +21,7 @@ module Dynflow
     require 'dynflow/action/polling'
     require 'dynflow/action/cancellable'
     require 'dynflow/action/with_sub_plans'
+    require 'dynflow/action/with_bulk_sub_plans'
 
     def self.all_children
       children.values.inject(children.values) do |children, child|

--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -1,4 +1,5 @@
 module Dynflow
+  # rubocop:disable Metrics/ClassLength
   class Action < Serializable
 
     OutputReference = ExecutionPlan::OutputReference
@@ -544,4 +545,5 @@ module Dynflow
       @trigger.nil?
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/dynflow/action/with_bulk_sub_plans.rb
+++ b/lib/dynflow/action/with_bulk_sub_plans.rb
@@ -1,0 +1,54 @@
+module Dynflow
+  module Action::WithBulkSubPlans
+    include Dynflow::Action::Cancellable
+
+    BATCH_SIZE=10
+
+    # Should return a slice of size items starting from item with index from
+    def entries(from, size)
+      raise NotImplementedError
+    end
+
+    def total_count
+      raise NotImplementedError
+    end
+
+    def current_batch
+      start_position = output[:total_count]
+      size = start_position + BATCH_SIZE > total_count ? total_count - start_position : BATCH_SIZE
+      entries(start_position, size)
+    end
+
+    def done?
+      super && total_count == output[:total_count]
+    end
+
+    def resume
+      # TODO
+      super
+    end
+
+    def run_progress
+      if counts_set? && output[:total_count] > 0
+        (output[:success_count] + output[:failed_count]).to_f / total_count
+      else
+        0.1
+      end
+    end
+
+    def try_to_finish
+      if can_spawn_next_batch?
+        spawn_plans
+      else
+        super
+      end
+    end
+
+    private
+
+    def can_spawn_next_batch?
+      total_count > output[:total_count]
+    end
+
+  end
+end

--- a/lib/dynflow/action/with_bulk_sub_plans.rb
+++ b/lib/dynflow/action/with_bulk_sub_plans.rb
@@ -9,6 +9,17 @@ module Dynflow
       raise NotImplementedError
     end
 
+    PlanNextBatch = Algebrick.atom
+
+    def run(event = nil)
+      if event === PlanNextBatch
+        spawn_plans if can_spawn_next_batch?
+        suspend
+      else
+        super
+      end
+    end
+
     # Should return the expected total count of tasks
     def total_count
       raise NotImplementedError
@@ -40,13 +51,10 @@ module Dynflow
       end
     end
 
-    def try_to_finish
-      # Start next batch if we can, try to finish otherwise
-      if can_spawn_next_batch?
-        spawn_plans
-      else
-        super
-      end
+    def spawn_plans
+      super
+    ensure
+      suspended_action << PlanNextBatch
     end
 
     private

--- a/lib/dynflow/action/with_bulk_sub_plans.rb
+++ b/lib/dynflow/action/with_bulk_sub_plans.rb
@@ -44,7 +44,7 @@ module Dynflow
     end
 
     def batch_size
-      DEAFULT_BATCH_SIZE
+      DEFAULT_BATCH_SIZE
     end
 
     # The same logic as in Action::WithSubPlans, but calculated using the expected total count

--- a/lib/dynflow/action/with_bulk_sub_plans.rb
+++ b/lib/dynflow/action/with_bulk_sub_plans.rb
@@ -17,8 +17,12 @@ module Dynflow
     # Returns the items in the current batch
     def current_batch
       start_position = output[:total_count]
-      size = start_position + BATCH_SIZE > total_count ? total_count - start_position : BATCH_SIZE
+      size = start_position + batch_size > total_count ? total_count - start_position : batch_size
       batch(start_position, size)
+    end
+
+    def batch_size
+      BATCH_SIZE
     end
 
     def done?

--- a/lib/dynflow/action/with_bulk_sub_plans.rb
+++ b/lib/dynflow/action/with_bulk_sub_plans.rb
@@ -2,34 +2,34 @@ module Dynflow
   module Action::WithBulkSubPlans
     include Dynflow::Action::Cancellable
 
-    BATCH_SIZE=10
+    BATCH_SIZE = 10
 
     # Should return a slice of size items starting from item with index from
-    def entries(from, size)
+    def batch(from, size)
       raise NotImplementedError
     end
 
+    # Should return the expected total count of tasks
     def total_count
       raise NotImplementedError
     end
 
+    # Returns the items in the current batch
     def current_batch
       start_position = output[:total_count]
       size = start_position + BATCH_SIZE > total_count ? total_count - start_position : BATCH_SIZE
-      entries(start_position, size)
+      batch(start_position, size)
     end
 
     def done?
+      # The action is done if the real total count equal to the expected total count and all of them
+      #   are either successful or failed
       super && total_count == output[:total_count]
     end
 
-    def resume
-      # TODO
-      super
-    end
-
+    # The same logic as in Action::WithSubPlans, but calculated using the expected total count
     def run_progress
-      if counts_set? && output[:total_count] > 0
+      if counts_set?
         (output[:success_count] + output[:failed_count]).to_f / total_count
       else
         0.1
@@ -37,6 +37,7 @@ module Dynflow
     end
 
     def try_to_finish
+      # Start next batch if we can, try to finish otherwise
       if can_spawn_next_batch?
         spawn_plans
       else

--- a/test/batch_sub_tasks_test.rb
+++ b/test/batch_sub_tasks_test.rb
@@ -1,0 +1,98 @@
+require_relative 'test_helper'
+
+module Dynflow
+  module BatchSubTaskTest
+    describe 'Batch sub-tasks' do
+      include PlanAssertions
+      include Dynflow::Testing::Assertions
+      include Dynflow::Testing::Factories
+      include TestHelpers
+
+      class FailureSimulator
+        def self.should_fail?
+          @should_fail
+        end
+
+        def self.should_fail!
+          @should_fail = true
+        end
+
+        def self.wont_fail!
+          @should_fail = false
+        end
+      end
+
+      let(:world) { WorldFactory.create_world }
+
+      class ChildAction < ::Dynflow::Action
+        def plan(should_fail = false)
+          raise "Simulated failure" if FailureSimulator.should_fail?
+          plan_self
+        end
+
+        def run
+          output[:run] = true
+        end
+      end
+
+      class ParentAction < ::Dynflow::Action
+        include Dynflow::Action::WithSubPlans
+        include Dynflow::Action::WithBulkSubPlans
+
+        def plan(count, concurrency_level = nil, time_span = nil)
+          limit_concurrency_level(concurrency_level) unless concurrency_level.nil?
+          distribute_over_time(time_span, count) unless time_span.nil?
+          plan_self :count => count
+        end
+
+        def create_sub_plans
+          output[:batch_count] ||= 0
+          output[:batch_count] += 1
+          current_batch.map { |i| trigger(ChildAction) }
+        end
+
+        def batch(from, size)
+          (1..total_count).to_a.slice(from, size)
+        end
+
+        def batch_size
+          5
+        end
+
+        def total_count
+          input[:count]
+        end
+      end
+
+      it 'starts tasks in batches' do
+        FailureSimulator.wont_fail!
+        plan = world.plan(ParentAction, 20)
+        future = world.execute plan.id
+        wait_for { future.completed? }
+        action = plan.entry_action
+
+        action.output[:batch_count].must_equal action.total_count / action.batch_size
+      end
+
+      it 'can resume tasks' do
+        FailureSimulator.should_fail!
+        plan = world.plan(ParentAction, 20)
+        future = world.execute plan.id
+        wait_for { future.completed? }
+        action = plan.entry_action
+        action.output[:batch_count].must_equal 1
+        future.value.state.must_equal :paused
+
+        FailureSimulator.wont_fail!
+        future = world.execute plan.id
+        wait_for { future.completed? }
+        action = future.value.entry_action
+        future.value.state.must_equal :stopped
+        action.output[:batch_count].must_equal (action.total_count / action.batch_size) + 1
+        action.output[:total_count].must_equal action.total_count
+        action.output[:success_count].must_equal action.total_count
+      end
+
+    end
+  end
+end

--- a/test/concurrency_control_test.rb
+++ b/test/concurrency_control_test.rb
@@ -63,7 +63,7 @@ module Dynflow
 
         def plan(count, concurrency_level = nil, time_span = nil, should_sleep = nil)
           limit_concurrency_level(concurrency_level) unless concurrency_level.nil?
-          distribute_over_time(time_span) unless time_span.nil?
+          distribute_over_time(time_span, count) unless time_span.nil?
           plan_self :count => count, :should_sleep => should_sleep
         end
 


### PR DESCRIPTION
### Quickstart Guide
- include the `::Dynflow::Action::WithBulkSubPlans` module into the action.
- implement `total_count` method returning the total count of plans we want to create
- implement `entries(FROM, SIZE)` method returning the batch starting at position `FROM` and spanning `SIZE` items
- the `BATCH_SIZE` constant can be redefined to change the size of the batch
- use `current_batch` inside `create_sub_plans` to get the current batch

### TODO
- [X] resuming paused tasks
- [X] tests
- [x] fix cancelling
- [ ] fix concurrency control after restart
