### PR TITLE
ActiveJob adapter

### DIFF
--- a/dynflow.gemspec
+++ b/dynflow.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack-test"
   s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-reporters"
-  s.add_development_dependency "activerecord"
+  s.add_development_dependency "activerecord", '< 5.0.0'
+  s.add_development_dependency 'activejob', '< 5.0.0'
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "sinatra"
 end

--- a/lib/dynflow.rb
+++ b/lib/dynflow.rb
@@ -49,4 +49,16 @@ module Dynflow
   require 'dynflow/semaphores'
   require 'dynflow/throttle_limiter'
   require 'dynflow/config'
+
+  if defined? ::ActiveJob
+    require 'dynflow/active_job/queue_adapter'
+
+    class Railtie < Rails::Railtie
+      config.before_initialize do
+        ::ActiveJob::QueueAdapters.include(
+          Dynflow::ActiveJob::QueueAdapters
+        )
+      end
+    end
+  end
 end

--- a/lib/dynflow/active_job/queue_adapter.rb
+++ b/lib/dynflow/active_job/queue_adapter.rb
@@ -1,0 +1,34 @@
+module Dynflow
+  module ActiveJob
+    module QueueAdapters
+      # To use Dynflow, set the queue_adapter config to +:dynflow+.
+      #
+      #   Rails.application.config.active_job.queue_adapter = :dynflow
+      class DynflowAdapter
+        extend ActiveSupport::Concern
+
+        class << self
+          def enqueue(job)
+            Rails.application.dynflow.world.trigger(JobWrapper, job.serialize)
+          end
+
+          def enqueue_at(job, timestamp)
+            Rails.application.dynflow.world.delay(JobWrapper, { :start_at => Time.at(timestamp) }, job.serialize)
+          end
+        end
+      end
+
+      class JobWrapper < Dynflow::Action
+        def plan(attributes)
+          input[:job_class] = attributes['job_class']
+          input[:job_arguments] = attributes['arguments']
+          plan_self
+        end
+
+        def run
+          input[:job_class].constantize.perform_now(*input[:job_arguments])
+        end
+      end
+    end
+  end
+end

--- a/test/activejob_adapter.rb
+++ b/test/activejob_adapter.rb
@@ -1,0 +1,48 @@
+require_relative 'test_helper'
+require 'active_job'
+require 'dynflow/active_job/queue_adapter'
+
+module Dynflow
+  class SampleJob < ::ActiveJob::Base
+    def perform(msg)
+      puts "This job says #{msg}"
+    end
+  end
+
+  describe 'running jobs' do
+    before(:all) do
+      world = WorldFactory.create_world
+      ::ActiveJob::QueueAdapters.include(::Dynflow::ActiveJob::QueueAdapters)
+      ::ActiveJob::Base.queue_adapter = :dynflow
+      dynflow_mock = Minitest::Mock.new
+      dynflow_mock.expect(:world, world)
+      rails_app_mock = Minitest::Mock.new
+      rails_app_mock .expect(:dynflow, dynflow_mock)
+      rails_mock = Minitest::Mock.new
+      rails_mock.expect(:application, rails_app_mock)
+      ::Rails = rails_mock
+    end
+
+    it 'is able to run the job right away' do
+      out, = capture_subprocess_io do
+        SampleJob.perform_now 'hello'
+      end
+      assert_match(/job says hello/, out)
+    end
+
+    it 'enqueues the job' do
+      out, = capture_subprocess_io do
+        SampleJob.perform_later 'hello'
+      end
+      assert_match(/Enqueued Dynflow::SampleJob/, out)
+    end
+
+    it 'schedules job in the future' do
+      out, = capture_subprocess_io do
+        SampleJob.set(:wait => 1.seconds).perform_later 'hello'
+      end
+      assert_match(/Enqueued Dynflow::SampleJob.*at.*UTC/, out)
+    end
+  end
+end
+


### PR DESCRIPTION
This commit adds an adapter to allow Dynflow to be used as an ActiveJob
backend. After this, jobs in Rails can be defined as ActiveJob::Base,
enqueued with "SampleJob.perform_later" or scheduled with
"SampleJob.set(:wait => 10.seconds).perform_later('abc')"

https://gist.github.com/anonymous/429e7171e867c94182839a4b0d1ddddc