### PR TITLE
Pin concurrent-ruby-ext to 1.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :concurrent_ruby_ext do
-  gem 'concurrent-ruby-ext', '~> 1.0'
+  gem 'concurrent-ruby-ext', '= 1.0.3'
 end
 
 group :pry do


### PR DESCRIPTION
New bundler has issues resolving more complicated dependencies,
pinning the ext we use for testing to 1.0.3 for now.