### PR TITLE
Ruby 2.0.0 compatibility for ActiveJob

### DIFF
--- a/lib/dynflow.rb
+++ b/lib/dynflow.rb
@@ -55,7 +55,8 @@ module Dynflow
 
     class Railtie < Rails::Railtie
       config.before_initialize do
-        ::ActiveJob::QueueAdapters.include(
+        ::ActiveJob::QueueAdapters.send(
+          :include,
           Dynflow::ActiveJob::QueueAdapters
         )
       end


### PR DESCRIPTION
Calling .include on a class does not work as it's a private method in
Ruby pre 2.1.

https://github.com/ruby/ruby/blob/v2_1_0/NEWS#L96 contains the info

```ruby
irb(main):001:0> RUBY_VERSION
=> "2.0.0"
irb(main):002:0> Module.public_instance_methods.grep(/^include$/)
=> []
irb(main):003:0> Module.private_instance_methods.grep(/^include$/)
=> [:include]

irb(main):001:0> RUBY_VERSION
=> "2.1.5"
irb(main):002:0> Module.public_instance_methods.grep(/^include$/)
=> [:include]
irb(main):003:0> Module.private_instance_methods.grep(/^include$/)
=> []

irb(main):001:0> RUBY_VERSION
=> "2.2.3"
irb(main):002:0> Module.public_instance_methods.grep(/^include$/)
=> [:include]
irb(main):003:0> Module.private_instance_methods.grep(/^include$/)
=> []
```

Sorry for the breakage @iNecas - if you can release .21 with this patch it'd be great as in https://github.com/theforeman/foreman/pull/4316 tests on Ruby 2.0 will not pass (including upgrade tests)