### PR TITLE
Add label to execution_plan

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -1,4 +1,5 @@
 module Dynflow
+  # rubocop:disable Metrics/ClassLength
   class Action < Serializable
 
     OutputReference = ExecutionPlan::OutputReference
@@ -120,6 +121,10 @@ module Dynflow
     def phase!(*phases)
       phase?(*phases) or
         raise TypeError, "Wrong phase #{phase}, required #{phases}"
+    end
+
+    def label
+      self.class.name
     end
 
     def input=(hash)

--- a/lib/dynflow/active_job/queue_adapter.rb
+++ b/lib/dynflow/active_job/queue_adapter.rb
@@ -28,6 +28,10 @@ module Dynflow
         def run
           input[:job_class].constantize.perform_now(*input[:job_arguments])
         end
+
+        def label
+          input[:job_class]
+        end
       end
     end
   end

--- a/lib/dynflow/persistence_adapters/sequel_migrations/010_add_execution_plans_label.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/010_add_execution_plans_label.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:dynflow_execution_plans) do
+      add_column :label, String
+    end
+  end
+end

--- a/test/execution_plan_test.rb
+++ b/test/execution_plan_test.rb
@@ -29,6 +29,7 @@ module Dynflow
 
           it 'restores the plan properly' do
             deserialized_execution_plan.id.must_equal execution_plan.id
+            deserialized_execution_plan.label.must_equal execution_plan.label
 
             assert_steps_equal execution_plan.root_plan_step, deserialized_execution_plan.root_plan_step
             assert_equal execution_plan.steps.keys, deserialized_execution_plan.steps.keys
@@ -44,6 +45,20 @@ module Dynflow
 
       end
 
+      describe '#label' do
+        let :execution_plan do
+          world.plan(Support::CodeWorkflowExample::FastCommit, 'sha' => 'abc123')
+        end
+
+        let :dummy_execution_plan do
+          world.plan(Support::CodeWorkflowExample::Dummy)
+        end
+
+        it 'is determined by the action#label method of entry action' do
+          execution_plan.label.must_equal 'Support::CodeWorkflowExample::FastCommit'
+          dummy_execution_plan.label.must_equal 'dummy_action'
+        end
+      end
       describe '#result' do
 
         let :execution_plan do

--- a/test/support/code_workflow_example.rb
+++ b/test/support/code_workflow_example.rb
@@ -214,6 +214,9 @@ module Support
     end
 
     class Dummy < Dynflow::Action
+      def label
+        'dummy_action'
+      end
     end
 
     class DummyWithFinalize < Dynflow::Action

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -9,7 +9,7 @@
   <thead>
     <tr>
       <th><%= order_link(:id, "Id") %></th>
-      <th><%= order_link(:action, "Action") %></th>
+      <th><%= order_link(:label, "Label") %></th>
       <th><%= order_link(:state, "State") %></th>
       <th><%= order_link(:result, "Result") %></th>
       <th><%= order_link(:started_at, "Started at") %></th>
@@ -20,7 +20,7 @@
 <% @plans.each do |plan| %>
   <tr>
     <td><%= h(plan.id) %></td>
-    <td><%= h(plan.root_plan_step.action_class.name) %></td>
+    <td><%= h(plan.label || plan.root_plan_step.action_class.name) %></td>
     <th><%= h(plan.state) %></th>
     <th><%= h(plan.result) %></th>
     <th><%= h(plan.started_at) %></th>

--- a/web/views/show.erb
+++ b/web/views/show.erb
@@ -1,4 +1,12 @@
 <p>
+  <b>Id:</b>
+  <%= h(@plan.id) %>
+</p>
+<p>
+  <b>Label:</b>
+  <%= h(@plan.label) %>
+</p>
+<p>
   <b>Status:</b>
   <%= h(@plan.state) %>
   <% if @plan.state == :paused %>


### PR DESCRIPTION
The value of the label is determined by the `action#label`. The default
goes to the `class.name` but can be overriden, for example ActiveJob can
override it with the job class name.