### PR TITLE
Fixes #19146 - handle invalid plans when invalidating worlds

### DIFF
--- a/lib/dynflow/errors.rb
+++ b/lib/dynflow/errors.rb
@@ -31,6 +31,9 @@ module Dynflow
       end
     end
 
+    class DataConsistencyError < Dynflow::Error
+    end
+
     class PersistenceError < Dynflow::Error
       def self.delegate(original_exception)
         self.new("caused by #{original_exception.class}: #{original_exception.message}").tap do |e|

--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -439,7 +439,12 @@ module Dynflow
       end
       # to make sure to we preserve the order of the steps
       step_ids.inject({}) do |hash, step_id|
-        hash[step_id.to_i] = ids_to_steps[step_id.to_i]
+        step = ids_to_steps[step_id.to_i]
+        if step.nil?
+          raise Errors::DataConsistencyError, "Could not load steps for execution plan #{execution_plan_id}"
+        else
+          hash[step_id.to_i] = step
+        end
         hash
       end
     end

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -295,6 +295,11 @@ module Dynflow
         coordinator.release(execution_lock)
         return
       end
+      unless plan.valid?
+        logger.error "invalid plan #{plan.id}, skipping"
+        coordinator.release(execution_lock)
+        return
+      end
       plan.execution_history.add('terminate execution', execution_lock.world_id)
 
       plan.steps.values.each do |step|

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -285,8 +285,13 @@ module Dynflow
     def invalidate_execution_lock(execution_lock)
       begin
         plan = persistence.load_execution_plan(execution_lock.execution_plan_id)
-      rescue KeyError => e
-        logger.error "invalidated execution plan #{execution_lock.execution_plan_id} missing, skipping"
+      rescue => e
+        if e.is_a?(KeyError)
+          logger.error "invalidated execution plan #{execution_lock.execution_plan_id} missing, skipping"
+        else
+          logger.error e
+          logger.error "unexpected error when invalidating execution plan #{execution_lock.execution_plan_id}, skipping"
+        end
         coordinator.release(execution_lock)
         return
       end

--- a/web/views/show.erb
+++ b/web/views/show.erb
@@ -12,7 +12,7 @@
   <% if @plan.state == :paused %>
     <a href="<%= url("/#{@plan.id}/resume") %>" class="postlink">Resume</a>
   <% end %>
-  <% if @plan.cancellable? %>
+  <% if @plan.valid? && @plan.cancellable? %>
     <a href="<%= url("/#{@plan.id}/cancel") %>" class="postlink">Cancel</a>
   <% end %>
 </p>
@@ -52,23 +52,33 @@
 
 <div class="tab-content">
   <div class="tab-pane" id="plan">
-    <%= erb :plan_step, locals: { step: @plan.root_plan_step } %>
+    <% if @plan.valid? %>
+      <%= erb :plan_step, locals: { step: @plan.root_plan_step } %>
+    <% else %>
+      N/A
+    <% end %>
   </div>
   <div class="tab-pane active" id="run">
-
-    <table class="flow-hint">
-      <tr>
-        <td class="border sequence"> </td>
-        <td>sequence</td>
-        <td class="border concurrence"> </td>
-        <td>concurrence</td>
-      </tr>
-    </table>
-
-    <%= erb :flow, locals: { flow: @plan.run_flow } %>
+    <% if @plan.valid? %>
+      <%= erb :flow, locals: { flow: @plan.run_flow } %>
+      <table class="flow-hint">
+        <tr>
+          <td class="border sequence"> </td>
+          <td>sequence</td>
+          <td class="border concurrence"> </td>
+          <td>concurrence</td>
+        </tr>
+      </table>
+    <% else %>
+      N/A
+    <% end %>
   </div>
   <div class="tab-pane" id="finalize">
-    <%= erb :flow, locals: { flow: @plan.finalize_flow } %>
+    <% if @plan.valid? %>
+      <%= erb :flow, locals: { flow: @plan.finalize_flow } %>
+    <% else %>
+      N/A
+    <% end %>
   </div>
   <div class="tab-pane" id="execution-history">
     <%= erb :execution_history %>


### PR DESCRIPTION
In a corner case, the data can be inconsistent in a way, that prevents
the world to be invalidate properly. Although this is usually a result
of unsafe manipulation with data on database level, we need to try
to resolve the situation to at least keep clean the runtime data properly,
as there is not much more we can do about it.