### PR TITLE
Remove things which will be deprecated in sequel >= 5

### DIFF
--- a/dynflow.gemspec
+++ b/dynflow.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "algebrick", '~> 0.7.0'
   s.add_dependency "concurrent-ruby", '~> 1.0'
   s.add_dependency "concurrent-ruby-edge", '~> 0.2.3'
-  s.add_dependency "sequel"
+  s.add_dependency "sequel", '>= 4.0.0'
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rack-test"

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -1,4 +1,4 @@
-require 'sequel/no_core_ext' # to avoid sequel ~> 3.0 coliding with ActiveRecord
+require 'sequel'
 require 'multi_json'
 
 module Dynflow
@@ -93,7 +93,7 @@ module Dynflow
 
       def find_past_delayed_plans(time)
         table(:delayed)
-          .where('start_at <= ? OR (start_before IS NOT NULL AND start_before <= ?)', time, time)
+          .where(::Sequel.lit('start_at <= ? OR (start_before IS NOT NULL AND start_before <= ?)', time, time))
           .order_by(:start_at)
           .all
           .map { |plan| load_data(plan) }


### PR DESCRIPTION
To get rid of
```ruby
SEQUEL DEPRECATION WARNING: requiring 'sequel/no_core_ext' is deprecated and will be removed in Sequel 5.  Just require 'sequel' instead.
<--- snip --->
SEQUEL DEPRECATION WARNING: Calling a dataset filtering method with multiple arguments or an array where the first argument/element is a string is deprecated and will be removed in Sequel 
5.  Use Sequel.lit("start_at <= ? OR (start_before IS NOT NULL AND start_before <= ?)", 2017-05-17 07:43:27 UTC, 2017-05-17 07:43:27 UTC) to create an SQL fragment expression and pass that
 to the dataset filtering method, or use the auto_literal_strings extension.
```

Maybe pinning activerecord and/or sequel versions might be reasonable