### PR TITLE
pin concurrent-ruby-edge to any version of the 0.2.x series

### DIFF
--- a/dynflow.gemspec
+++ b/dynflow.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "apipie-params"
   s.add_dependency "algebrick", '~> 0.7.0'
   s.add_dependency "concurrent-ruby", '~> 1.0'
-  s.add_dependency "concurrent-ruby-edge", '~> 0.2.3'
+  s.add_dependency "concurrent-ruby-edge", '~> 0.2.0'
   s.add_dependency "sequel", '>= 4.0.0'
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
in e9c89e7 we pinned concurrent-ruby-edge to ~> 0.2.3, because that was the latest available version at that time. but in reality we really want *any* version of the 0.2.x series, just not 0.3.x. let's soften the 
dependency accordingly. this allows the use of dynflow with older c-r-e releases.

I did run the unit-tests on both, c-r-e 0.2.0 and 0.2.4, and they run fine.