### PR TITLE
Pin sinatra to 1.4.8 for ruby < 2.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ end
 
 if RUBY_VERSION < "2.2.2"
   gem 'activesupport', '~> 4.2'
+  gem 'sinatra', '~> 1.4.8'
 end
 
 group :lint do


### PR DESCRIPTION
Due to requirements on dependencies