### PR TITLE
Refs #20352 - Backup execution plans on their deletion

### DIFF
--- a/lib/dynflow/config.rb
+++ b/lib/dynflow/config.rb
@@ -115,6 +115,14 @@ module Dynflow
       { 'hostname' => Socket.gethostname, 'pid' => Process.pid }
     end
 
+    config_attr :backup_deleted_plans, Algebrick::Types::Boolean do
+      false
+    end
+
+    config_attr :backup_dir, String, NilClass do
+      './backup'
+    end
+
     def validate(config_for_world)
       if defined? ::ActiveRecord::Base
         ar_pool_size = ::ActiveRecord::Base.connection_pool.instance_variable_get(:@size)

--- a/lib/dynflow/persistence.rb
+++ b/lib/dynflow/persistence.rb
@@ -40,13 +40,13 @@ module Dynflow
       end
     end
 
-    # - presunout current backup dir do persistence
-    # - v persistence se urci dir a bude ho mozne pretizit pomoci parametru
-    # - v tasks nactu z persistence current dir a pouziju ho
-    # - export_to_csv presunout do class method adapteru sequel. Volat ho z tasks
+    def delete_execution_plans(filters, batch_size = 1000, enforce_backup_dir = nil)
+      backup_dir = enforce_backup_dir || (@backup_deleted_plans ? current_backup_dir : nil)
+      adapter.delete_execution_plans(filters, batch_size, backup_dir)
+    end
 
-    def delete_execution_plans(filters, batch_size = 1000)
-      adapter.delete_execution_plans(filters, batch_size, @backup_deleted_plans ? @backup_dir : nil)
+    def current_backup_dir
+      File.join(@backup_dir, Date.today.strftime('%Y%m%d'))
     end
 
     def load_execution_plan(id)

--- a/lib/dynflow/persistence.rb
+++ b/lib/dynflow/persistence.rb
@@ -8,10 +8,12 @@ module Dynflow
 
     attr_reader :adapter
 
-    def initialize(world, persistence_adapter)
+    def initialize(world, persistence_adapter, options = {})
       @world   = world
       @adapter = persistence_adapter
       @adapter.register_world(world)
+      @backup_deleted_plans = options.fetch(:backup_deleted_plans, false)
+      @backup_dir = options.fetch(:backup_dir, './backup')
     end
 
     def load_action(step)
@@ -38,8 +40,13 @@ module Dynflow
       end
     end
 
+    # - presunout current backup dir do persistence
+    # - v persistence se urci dir a bude ho mozne pretizit pomoci parametru
+    # - v tasks nactu z persistence current dir a pouziju ho
+    # - export_to_csv presunout do class method adapteru sequel. Volat ho z tasks
+
     def delete_execution_plans(filters, batch_size = 1000)
-      adapter.delete_execution_plans(filters, batch_size)
+      adapter.delete_execution_plans(filters, batch_size, @backup_deleted_plans ? @backup_dir : nil)
     end
 
     def load_execution_plan(id)

--- a/lib/dynflow/persistence.rb
+++ b/lib/dynflow/persistence.rb
@@ -41,12 +41,12 @@ module Dynflow
     end
 
     def delete_execution_plans(filters, batch_size = 1000, enforce_backup_dir = nil)
-      backup_dir = enforce_backup_dir || (@backup_deleted_plans ? current_backup_dir : nil)
+      backup_dir = enforce_backup_dir || current_backup_dir
       adapter.delete_execution_plans(filters, batch_size, backup_dir)
     end
 
     def current_backup_dir
-      File.join(@backup_dir, Date.today.strftime('%Y%m%d'))
+      @backup_deleted_plans ? File.join(@backup_dir, Date.today.strftime('%Y%m%d')) : nil
     end
 
     def load_execution_plan(id)

--- a/lib/dynflow/persistence_adapters/abstract.rb
+++ b/lib/dynflow/persistence_adapters/abstract.rb
@@ -43,7 +43,9 @@ module Dynflow
       #   what to delete
       # @param batch_size the size of the chunks to iterate over when
       #   performing the deletion
-      def delete_execution_plans(filters, batch_size = 1000)
+      # @param backup_dir where the backup of deleted plans will be created.
+      #   Set to nil for no backup
+      def delete_execution_plans(filters, batch_size = 1000, backup_dir = nil)
         raise NotImplementedError
       end
 

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -1,5 +1,7 @@
 require 'sequel'
 require 'multi_json'
+require 'fileutils'
+require 'csv'
 
 module Dynflow
   module PersistenceAdapters
@@ -58,18 +60,46 @@ module Dynflow
         data_set.all.map { |record| load_data(record) }
       end
 
-      def delete_execution_plans(filters, batch_size = 1000)
+      def delete_execution_plans(filters, batch_size = 1000, backup_dir = nil)
         count = 0
+        current_dir = current_backup_dir(backup_dir) if backup_dir
         filter(:execution_plan, table(:execution_plan), filters).each_slice(batch_size) do |plans|
           uuids = plans.map { |p| p.fetch(:uuid) }
           @db.transaction do
             table(:delayed).where(execution_plan_uuid: uuids).delete
-            table(:step).where(execution_plan_uuid: uuids).delete
-            table(:action).where(execution_plan_uuid: uuids).delete
-            count += table(:execution_plan).where(uuid: uuids).delete
+
+            steps = table(:step).where(execution_plan_uuid: uuids)
+            backup_to_csv(steps, current_dir, 'steps.csv') if backup_dir
+            steps.delete
+
+            actions = table(:action).where(execution_plan_uuid: uuids)
+            backup_to_csv(actions, current_dir, 'actions.csv') if backup_dir
+            actions.delete
+
+            execution_plans = table(:execution_plan).where(uuid: uuids)
+            backup_to_csv(execution_plans, current_dir, 'execution_plans.csv') if backup_dir
+            count += execution_plans.delete
           end
         end
         return count
+      end
+
+      def current_backup_dir(backup_dir)
+        File.join(backup_dir, Date.today.strftime('%Y%m%d'))
+      end
+
+      def backup_to_csv(dataset, backup_dir, file_name)
+        FileUtils.mkdir_p(backup_dir) unless File.directory?(backup_dir)
+        csv_file = File.join(backup_dir, file_name)
+        appending = File.exist?(csv_file)
+        columns = dataset.columns
+        File.open(csv_file, 'a') do |csv|
+          csv << columns.to_csv unless appending
+          dataset.each do |row|
+            csv << columns.collect { |col| row[col] }.to_csv
+          end
+        end
+        dataset
       end
 
       def load_execution_plan(execution_plan_id)

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -83,22 +83,6 @@ module Dynflow
         return count
       end
 
-
-
-      def backup_to_csv(dataset, backup_dir, file_name)
-        FileUtils.mkdir_p(backup_dir) unless File.directory?(backup_dir)
-        csv_file = File.join(backup_dir, file_name)
-        appending = File.exist?(csv_file)
-        columns = dataset.columns
-        File.open(csv_file, 'a') do |csv|
-          csv << columns.to_csv unless appending
-          dataset.each do |row|
-            csv << columns.collect { |col| row[col] }.to_csv
-          end
-        end
-        dataset
-      end
-
       def load_execution_plan(execution_plan_id)
         load :execution_plan, uuid: execution_plan_id
       end
@@ -295,6 +279,24 @@ module Dynflow
 
       def load_data(record)
         Utils.indifferent_hash(MultiJson.load(record[:data]))
+      end
+
+      def ensure_backup_dir(backup_dir)
+        FileUtils.mkdir_p(backup_dir) unless File.directory?(backup_dir)
+      end
+
+      def backup_to_csv(dataset, backup_dir, file_name)
+        ensure_backup_dir(backup_dir)
+        csv_file = File.join(backup_dir, file_name)
+        appending = File.exist?(csv_file)
+        columns = dataset.columns
+        File.open(csv_file, 'a') do |csv|
+          csv << columns.to_csv unless appending
+          dataset.each do |row|
+            csv << columns.collect { |col| row[col] }.to_csv
+          end
+        end
+        dataset
       end
 
       def delete(what, condition)

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -17,7 +17,9 @@ module Dynflow
       @logger_adapter         = config_for_world.logger_adapter
       config_for_world.validate
       @transaction_adapter    = config_for_world.transaction_adapter
-      @persistence            = Persistence.new(self, config_for_world.persistence_adapter)
+      @persistence            = Persistence.new(self, config_for_world.persistence_adapter,
+                                                :backup_deleted_plans => config_for_world.backup_deleted_plans,
+                                                :backup_dir => config_for_world.backup_dir)
       @coordinator            = Coordinator.new(config_for_world.coordinator_adapter)
       @executor               = config_for_world.executor
       @action_classes         = config_for_world.action_classes

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -156,17 +156,17 @@ module Dynflow
             -> { adapter.load_execution_plan('plan3') }.must_raise KeyError
           end
 
-          it 'creates daily dir and produce backup including steps and actions' do
+          it 'creates backup dir and produce backup including steps and actions' do
             prepare_plans_with_steps
             Dir.mktmpdir do |backup_dir|
               adapter.delete_execution_plans({'uuid' => 'plan1'}, 100, backup_dir).must_equal 1
-              plans = CSV.read(Dir[backup_dir + "/*/execution_plans.csv"].first, :headers => true)
+              plans = CSV.read(backup_dir + "/execution_plans.csv", :headers => true)
               assert_equal 1, plans.count
               assert_equal 'plan1', plans.first.to_hash['uuid']
-              actions = CSV.read(Dir[backup_dir + "/*/actions.csv"].first, :headers => true)
+              actions = CSV.read(backup_dir + "/actions.csv", :headers => true)
               assert_equal 1, actions.count
               assert_equal 'plan1', actions.first.to_hash['execution_plan_uuid']
-              steps = CSV.read(Dir[backup_dir + "/*/steps.csv"].first, :headers => true)
+              steps = CSV.read(backup_dir +"/steps.csv", :headers => true)
               assert_equal 1, steps.count
               assert_equal 'plan1', steps.first.to_hash['execution_plan_uuid']
             end

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -1,4 +1,5 @@
 require_relative 'test_helper'
+require 'tmpdir'
 
 module Dynflow
   module PersistenceTest
@@ -153,6 +154,22 @@ module Dynflow
             -> { adapter.load_execution_plan('plan1') }.must_raise KeyError
             adapter.load_execution_plan('plan2') # nothing raised
             -> { adapter.load_execution_plan('plan3') }.must_raise KeyError
+          end
+
+          it 'creates daily dir and produce backup including steps and actions' do
+            prepare_plans_with_steps
+            Dir.mktmpdir do |backup_dir|
+              adapter.delete_execution_plans({'uuid' => 'plan1'}, 100, backup_dir).must_equal 1
+              plans = CSV.read(Dir[backup_dir + "/*/execution_plans.csv"].first, :headers => true)
+              assert_equal 1, plans.count
+              assert_equal 'plan1', plans.first.to_hash['uuid']
+              actions = CSV.read(Dir[backup_dir + "/*/actions.csv"].first, :headers => true)
+              assert_equal 1, actions.count
+              assert_equal 'plan1', actions.first.to_hash['execution_plan_uuid']
+              steps = CSV.read(Dir[backup_dir + "/*/steps.csv"].first, :headers => true)
+              assert_equal 1, steps.count
+              assert_equal 'plan1', steps.first.to_hash['execution_plan_uuid']
+            end
           end
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -82,16 +82,18 @@ module WorldFactory
   end
 
   def self.test_world_config
-    config                     = Dynflow::Config.new
-    config.persistence_adapter = persistence_adapter
-    config.logger_adapter      = logger_adapter
-    config.coordinator_adapter = coordinator_adapter
-    config.delayed_executor    = nil
-    config.auto_rescue         = false
-    config.auto_validity_check = false
-    config.exit_on_terminate   = false
-    config.auto_execute        = false
-    config.auto_terminate      = false
+    config                      = Dynflow::Config.new
+    config.persistence_adapter  = persistence_adapter
+    config.logger_adapter       = logger_adapter
+    config.coordinator_adapter  = coordinator_adapter
+    config.delayed_executor     = nil
+    config.auto_rescue          = false
+    config.auto_validity_check  = false
+    config.exit_on_terminate    = false
+    config.auto_execute         = false
+    config.auto_terminate       = false
+    config.backup_deleted_plans = false
+    config.backup_dir           = nil
     yield config if block_given?
     return config
   end


### PR DESCRIPTION
When execution plan is deleted it is exported along with actions and
steps. The backup is controlled by two configuration options -
backup_deleted_plans and backup_dir. The data are exported in CSV format
one file per plans, actions and steps. The files are created under the
backup_dir and daily subdirs for easier rotations.