### PR TITLE
Execution plan cleaner

### DIFF
--- a/lib/dynflow.rb
+++ b/lib/dynflow.rb
@@ -24,6 +24,7 @@ module Dynflow
   require 'dynflow/utils'
   require 'dynflow/round_robin'
   require 'dynflow/actor'
+  require 'dynflow/actors'
   require 'dynflow/errors'
   require 'dynflow/serializer'
   require 'dynflow/serializable'

--- a/lib/dynflow/actors.rb
+++ b/lib/dynflow/actors.rb
@@ -1,0 +1,5 @@
+module Dynflow
+  module Actors
+    require 'dynflow/actors/execution_plan_cleaner'
+  end
+end

--- a/lib/dynflow/actors/execution_plan_cleaner.rb
+++ b/lib/dynflow/actors/execution_plan_cleaner.rb
@@ -1,0 +1,52 @@
+module Dynflow
+  module Actors
+    class ExecutionPlanCleaner
+      attr_reader :core
+
+      def initialize(world, options = {})
+        @world = world
+        @options = options
+      end
+
+      def core_class
+        Core
+      end
+
+      def spawn
+        Concurrent.future.tap do |initialized|
+          @core = core_class.spawn(:name => 'execution-plan-cleaner',
+                                   :args => [@world, @options],
+                                   :initialized => initialized)
+        end
+      end
+
+      def clean!
+        core.tell([:clean!])
+      end
+
+      class Core < Actor
+        def initialize(world, options = {})
+          @world = world
+          default_age = 60 * 60 * 24 # One day by default
+          @poll_interval = options.fetch(:poll_interval, default_age)
+          @max_age = options.fetch(:max_age, default_age)
+          start
+        end
+
+        def start
+          set_clock
+          clean!
+        end
+
+        def clean!
+          plans = @world.persistence.find_old_execution_plans(Time.now.utc - @max_age)
+          @world.persistence.delete_execution_plans(uuid: plans.map(&:id))
+        end
+
+        def set_clock
+          @world.clock.ping(self, @poll_interval, :start)
+        end
+      end
+    end
+  end
+end

--- a/lib/dynflow/config.rb
+++ b/lib/dynflow/config.rb
@@ -107,6 +107,10 @@ module Dynflow
       ::Dynflow::ThrottleLimiter.new(world)
     end
 
+    config_attr :execution_plan_cleaner, ::Dynflow::Actors::ExecutionPlanCleaner, NilClass do |world|
+      nil
+    end
+
     config_attr :action_classes do
       Action.all_children
     end

--- a/lib/dynflow/coordinator.rb
+++ b/lib/dynflow/coordinator.rb
@@ -187,6 +187,17 @@ module Dynflow
       end
     end
 
+    class ExecutionPlanCleanerLock < LockByWorld
+      def initialize(world)
+        super
+        @data[:id] = self.class.lock_id
+      end
+
+      def self.lock_id
+        "execution-plan-cleaner"
+      end
+    end
+
     class WorldInvalidationLock < LockByWorld
       def initialize(world, invalidated_world)
         super(world)

--- a/lib/dynflow/delayed_executors/abstract.rb
+++ b/lib/dynflow/delayed_executors/abstract.rb
@@ -18,18 +18,18 @@ module Dynflow
         @core.ask(:terminate!)
       end
 
-      private
-
-      def core_class
-        raise NotImplementedError
-      end
-
       def spawn
         Concurrent.future.tap do |initialized|
           @core = core_class.spawn name: 'delayed-executor',
                                    args: [@world, @options],
                                    initialized: initialized
         end
+      end
+
+      private
+
+      def core_class
+        raise NotImplementedError
       end
 
     end

--- a/lib/dynflow/persistence.rb
+++ b/lib/dynflow/persistence.rb
@@ -58,6 +58,12 @@ module Dynflow
       adapter.save_execution_plan(execution_plan.id, execution_plan.to_hash)
     end
 
+    def find_old_execution_plans(age)
+      adapter.find_old_execution_plans(age).map do |plan|
+        ExecutionPlan.new_from_hash(plan, @world)
+      end
+    end
+
     def find_past_delayed_plans(time)
       adapter.find_past_delayed_plans(time).map do |plan|
         DelayedPlan.new_from_hash(@world, plan)

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -102,6 +102,12 @@ module Dynflow
         count
       end
 
+      def find_old_execution_plans(age)
+        table(:execution_plan)
+          .where(::Sequel.lit('ended_at <= ? AND state = ?', age, 'stopped'))
+          .all.map { |plan| load_data plan }
+      end
+
       def find_past_delayed_plans(time)
         table(:delayed)
           .where(::Sequel.lit('start_at <= ? OR (start_before IS NOT NULL AND start_before <= ?)', time, time))

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -8,7 +8,7 @@ module Dynflow
                 :transaction_adapter, :logger_adapter, :coordinator,
                 :persistence, :action_classes, :subscription_index,
                 :middleware, :auto_rescue, :clock, :meta, :delayed_executor, :auto_validity_check, :validity_check_timeout, :throttle_limiter,
-                :terminated
+                :terminated, :execution_plan_cleaner
 
     def initialize(config)
       @id                     = SecureRandom.uuid

--- a/test/execution_plan_cleaner_test.rb
+++ b/test/execution_plan_cleaner_test.rb
@@ -1,0 +1,79 @@
+require_relative 'test_helper'
+require 'mocha/mini_test'
+
+module Dynflow
+  module ExecutionPlanCleanerTest
+    describe ::Dynflow::Actors::ExecutionPlanCleaner do
+      include Dynflow::Testing::Assertions
+      include Dynflow::Testing::Factories
+      include TestHelpers
+
+      class SimpleAction < ::Dynflow::Action
+        def plan; end
+      end
+
+      before do
+        world.persistence.delete_execution_plans({})
+      end
+
+      let(:default_world) { WorldFactory.create_world }
+      let(:age) { 10 }
+      let(:world) do
+        WorldFactory.create_world do |config|
+          config.execution_plan_cleaner = proc do |world|
+            ::Dynflow::Actors::ExecutionPlanCleaner.new(world, :max_age => age)
+          end
+        end
+      end
+      let(:clock) { Testing::ManagedClock.new }
+
+      it 'is disabled by default' do
+        default_world.execution_plan_cleaner.must_be_nil
+        world.execution_plan_cleaner
+             .must_be_instance_of ::Dynflow::Actors::ExecutionPlanCleaner
+      end
+
+      it 'periodically looks for old execution plans' do
+        world.stub(:clock, clock) do
+          clock.pending_pings.count.must_equal 0
+          world.execution_plan_cleaner.core.ask!(:start)
+          clock.pending_pings.count.must_equal 1
+          world.persistence.expects(:find_old_execution_plans).returns([])
+          world.persistence.expects(:delete_execution_plans).with(:uuid => [])
+          clock.progress
+          wait_for { clock.pending_pings.count == 1 }
+        end
+      end
+
+      it 'cleans up old plans' do
+        world.stub(:clock, clock) do
+          world.execution_plan_cleaner.core.ask!(:start)
+          clock.pending_pings.count.must_equal 1
+          plans = (1..10).map { world.trigger SimpleAction }
+                         .each { |plan| plan.finished.wait }
+          world.persistence.find_execution_plans(:uuid => plans.map(&:id))
+               .each do |plan|
+            plan.instance_variable_set(:@ended_at, plan.ended_at - 15)
+            plan.save
+          end
+          world.execution_plan_cleaner.core.ask!(:clean!)
+          world.persistence.find_execution_plans(:uuid => plans.map(&:id))
+               .count.must_equal 0
+        end
+      end
+
+      it 'leaves "new enough" plans intact' do
+        world.stub(:clock, clock) do
+          count = 10
+          world.execution_plan_cleaner.core.ask!(:start)
+          clock.pending_pings.count.must_equal 1
+          plans = (1..10).map { world.trigger SimpleAction }
+                         .each { |plan| plan.finished.wait }
+          world.execution_plan_cleaner.core.ask!(:clean!)
+          world.persistence.find_execution_plans(:uuid => plans.map(&:id))
+               .count.must_equal count
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It is disabled by default, needs to be enabled in a world's config. For the usage on smart-proxy this should be good to go since there's mostly one or two kinds of tasks (rex and ansible), so we probably don't need fine grained controls for setting different interval for different actions.