### PR TITLE
Rescue strategy fixes and enhancements

### DIFF
--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -151,7 +151,8 @@ module Dynflow
     end
 
     def rescue_strategy
-      Type! entry_action.rescue_strategy, Action::Rescue::Strategy
+      rescue_strategy = entry_action.rescue_strategy || Action::Rescue::Skip
+      Type! rescue_strategy, Action::Rescue::Strategy
     end
 
     def sub_plans

--- a/test/rescue_test.rb
+++ b/test/rescue_test.rb
@@ -34,7 +34,6 @@ module Dynflow
           rescued_plan.entry_action.output[:message].
             must_equal "skipped because some error as you wish"
         end
-
       end
 
       describe 'of simple skippable action in finalize phase' do
@@ -87,6 +86,9 @@ module Dynflow
         end
 
         it 'skips the action and continues' do
+          # we need to rescue twice for two errors in sequence
+          rescued_plan = execution_plan.rescue_from_error.value
+          rescued_plan = rescued_plan.rescue_from_error.value
           rescued_plan.state.must_equal :stopped
           rescued_plan.result.must_equal :warning
           skipped_action = rescued_plan.actions.find do |action|

--- a/test/rescue_test.rb
+++ b/test/rescue_test.rb
@@ -127,8 +127,8 @@ module Dynflow
           proc { rescued_plan }.must_raise Errors::RescueError
           execution_plan.state.must_equal :stopped
           execution_plan.result.must_equal :error
-          execution_plan.steps_in_state(:success).count.must_equal 5
-          execution_plan.steps_in_state(:pending).count.must_equal 4
+          execution_plan.steps_in_state(:success).count.must_equal 6
+          execution_plan.steps_in_state(:pending).count.must_equal 6
           execution_plan.steps_in_state(:error).count.must_equal 1
         end
 
@@ -190,8 +190,8 @@ module Dynflow
           it 'fails the execution plan automatically' do
             execution_plan.state.must_equal :stopped
             execution_plan.result.must_equal :error
-            execution_plan.steps_in_state(:success).count.must_equal 5
-            execution_plan.steps_in_state(:pending).count.must_equal 4
+            execution_plan.steps_in_state(:success).count.must_equal 6
+            execution_plan.steps_in_state(:pending).count.must_equal 6
             execution_plan.steps_in_state(:error).count.must_equal 1
           end
         end

--- a/test/support/rescue_example.rb
+++ b/test/support/rescue_example.rb
@@ -92,6 +92,7 @@ module Support
             plan_action(ActionWithFail, 4, error_state)
           end
           plan_action(ActionWithFail, 5, :success)
+          plan_action(ActionWithSkip, 6, :success)
         end
       end
 

--- a/test/support/rescue_example.rb
+++ b/test/support/rescue_example.rb
@@ -10,8 +10,9 @@ module Support
           concurrence do
             plan_action(ActionWithSkip, 3, :success)
             plan_action(ActionWithSkip, 4, error_state)
+            plan_action(ActionWithSkip, 5, error_state)
           end
-          plan_action(ActionWithSkip, 5, :success)
+          plan_action(ActionWithSkip, 6, :success)
         end
       end
 


### PR DESCRIPTION
This PR includes two fixes for rescue strategy

Fixes #20647 - fix calculation of rescue strategy for complex actions

Since ba6300f, we were considering also pending and successful steps when
calculating the rescue strategy. This made the auto_rescue not working
properly, as any action with `Pause` rescue strategy (which is considered
by default) would lead to pause of the task.

This change makes the rescue strategy working properly again, while keeping
the Fail strategy working as well.

Fixes #20648 - support for multiple auto-rescues in the plan

Currently, when an error occurs and skip rescue strategy applies, it
auto-rescues only at the first failure: the auto-rescue is not applied for
further failures.

After this change, we don't check only if the plan was already rescued or
not, but we check, if there is some failed action that we have not tried to
rescue from yet: this is better check to ensure we don't run into endless
loop, while allowing to auto-rescue several times in a row.