### PR TITLE
Fix Rails 5 compatibility

### DIFF
--- a/lib/dynflow/rails/configuration.rb
+++ b/lib/dynflow/rails/configuration.rb
@@ -75,7 +75,7 @@ module Dynflow
       end
 
       def rake_task_with_executor?
-        return false unless defined?(::Rake)
+        return false unless defined?(::Rake) && ::Rake.respond_to?(:application)
 
         ::Rake.application.top_level_tasks.any? do |rake_task|
           rake_tasks_with_executor.include?(rake_task)


### PR DESCRIPTION
In Rails 5 Rake is defined but `Rake.application` is only present when running via rake.