### PR TITLE
Introduce Singleton action module

### DIFF
--- a/examples/singletons.rb
+++ b/examples/singletons.rb
@@ -17,12 +17,11 @@ DESC
 require_relative 'example_helper'
 
 class SingletonExample < Dynflow::Action
+  middleware.use ::Dynflow::Middleware::Common::Singleton
   include Dynflow::Action::Singleton
 
   def run
-    with_valid_singleton_lock do
-      sleep 10
-    end
+    sleep 10
   end
 end
 

--- a/examples/singletons.rb
+++ b/examples/singletons.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+example_description = <<DESC
+
+  Sub Plans Example
+  ===================
+
+  This example shows, how singleton actions can be used for making sure
+  there is only one instance of the action running at a time.
+
+  Singleton actions try to obtain a lock at the beggining of their plan
+  phase and fail if they can't do so. In run phase they check if they
+  have the lock and try to acquire it again if they don't. These actions
+  release the lock at the end of their finalize phase.
+
+DESC
+
+require_relative 'example_helper'
+
+class SingletonExample < Dynflow::Action
+  include Dynflow::Action::Singleton
+
+  def run
+    with_valid_singleton_lock do
+      sleep 10
+    end
+  end
+end
+
+class SingletonExampleA < SingletonExample; end
+class SingletonExampleB < SingletonExample; end
+
+if $0 == __FILE__
+  ExampleHelper.world.action_logger.level = Logger::INFO
+  ExampleHelper.world
+  t1 = ExampleHelper.world.trigger(SingletonExampleA)
+  t2 = ExampleHelper.world.trigger(SingletonExampleA)
+  ExampleHelper.world.trigger(SingletonExampleA) unless SingletonExampleA.singleton_locked?(ExampleHelper.world)
+  t3 = ExampleHelper.world.trigger(SingletonExampleB)
+  db = ExampleHelper.world.persistence.adapter.db
+
+  puts example_description
+  puts <<-MSG.gsub(/^.*\|/, '')
+    |  3 execution plans were triggered:
+    |  #{t1.id} should finish successfully
+    |  #{t3.id} should finish successfully because it is a singleton of different class
+    |  #{t2.id} should fail because #{t1.id} holds the lock
+    |  
+    |  You can see the details at
+    |    http://localhost:4567/#{t1.id}
+    |    http://localhost:4567/#{t2.id}
+    |    http://localhost:4567/#{t3.id}
+    |
+  MSG
+  ExampleHelper.run_web_console
+end

--- a/examples/singletons.rb
+++ b/examples/singletons.rb
@@ -44,7 +44,7 @@ if $0 == __FILE__
     |  #{t1.id} should finish successfully
     |  #{t3.id} should finish successfully because it is a singleton of different class
     |  #{t2.id} should fail because #{t1.id} holds the lock
-    |  
+    |
     |  You can see the details at
     |    http://localhost:4567/#{t1.id}
     |    http://localhost:4567/#{t2.id}

--- a/examples/singletons.rb
+++ b/examples/singletons.rb
@@ -17,7 +17,6 @@ DESC
 require_relative 'example_helper'
 
 class SingletonExample < Dynflow::Action
-  middleware.use ::Dynflow::Middleware::Common::Singleton
   include Dynflow::Action::Singleton
 
   def run

--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -21,6 +21,7 @@ module Dynflow
 
     require 'dynflow/action/polling'
     require 'dynflow/action/cancellable'
+    require 'dynflow/action/singleton'
     require 'dynflow/action/with_sub_plans'
     require 'dynflow/action/with_bulk_sub_plans'
     require 'dynflow/action/with_polling_sub_plans'
@@ -548,6 +549,16 @@ module Dynflow
 
     def root_action?
       @triggering_action.nil?
+    end
+
+    # An action must be a singleton and have a singleton lock
+    def self.singleton_locked?(world)
+      if self.ancestors.include? ::Dynflow::Action::Singleton
+        lock_class = ::Dynflow::Coordinator::SingletonActionLock
+        !world.coordinator.find_locks(lock_class.unique_filter(self.name)).empty?
+      else
+        false
+      end
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -303,6 +303,10 @@ module Dynflow
       @serializer
     end
 
+    def holds_singleton_lock?
+      false
+    end
+
     protected
 
     def state=(state)
@@ -555,7 +559,7 @@ module Dynflow
     def self.singleton_locked?(world)
       if self.ancestors.include? ::Dynflow::Action::Singleton
         lock_class = ::Dynflow::Coordinator::SingletonActionLock
-        !world.coordinator.find_locks(lock_class.unique_filter(self.name)).empty?
+        world.coordinator.find_locks(lock_class.unique_filter(self.name)).any?
       else
         false
       end

--- a/lib/dynflow/action/singleton.rb
+++ b/lib/dynflow/action/singleton.rb
@@ -7,6 +7,7 @@ module Dynflow
       end
 
       def run(event = nil)
+        # At the beginning of the run phase, verify we have the lock or fail
         validate_singleton_lock!
       end
 
@@ -22,18 +23,7 @@ module Dynflow
       end
 
       def validate_singleton_lock!
-        # Get locks for this action, there should be none or one
-        lock_filter = singleton_lock_class.unique_filter(self.class.name)
-        present_locks = world.coordinator.find_locks lock_filter
-        if present_locks.empty?
-          # The lock got lost somehow, acquire it again
-          singleton_lock!
-        else
-          if present_locks.first.owner_id != execution_plan_id
-            # The lock is acquired by another action
-            fail "Action #{self.class.name} is already active"
-          end
-        end
+        singleton_lock! unless holds_singleton_lock?
       end
 
       def singleton_lock!
@@ -43,7 +33,14 @@ module Dynflow
       end
 
       def singleton_unlock!
-        world.coordinator.release(singleton_lock)
+        world.coordinator.release(singleton_lock) if holds_singleton_lock?
+      end
+
+      def holds_singleton_lock?
+        # Get locks for this action, there should be none or one
+        lock_filter = singleton_lock_class.unique_filter(self.class.name)
+        present_locks = world.coordinator.find_locks lock_filter
+        !present_locks.empty? && present_locks.first.owner_id == execution_plan_id
       end
 
       def singleton_lock_class

--- a/lib/dynflow/action/singleton.rb
+++ b/lib/dynflow/action/singleton.rb
@@ -1,0 +1,63 @@
+module Dynflow
+  class Action
+    module Singleton
+      def plan(*args)
+        singleton_lock!
+        plan_self(*args)
+      end
+      
+      def run(event = nil)
+        validate_singleton_lock!
+      end
+
+      def finalize
+        singleton_unlock!
+      end
+
+      private
+
+      def with_valid_singleton_lock
+        validate_singleton_lock!
+        yield
+      end
+
+      def validate_singleton_lock!
+        # Get locks for this action, there should be none or one
+        lock_filter = singleton_lock_class.unique_filter(self.class.name)
+        present_locks = world.coordinator.find_locks lock_filter
+        if present_locks.empty?
+          # The lock got lost somehow, acquire it again
+          singleton_lock!
+        else
+          if present_locks.first.owner_id != execution_plan_id
+            # The lock is acquired by another action
+            fail "Action #{self.class.name} is already active"
+          end
+        end
+      end
+
+      def singleton_lock!
+        world.coordinator.acquire(singleton_lock)
+      rescue Dynflow::Coordinator::LockError
+        fail "Action #{self.class.name} is already active"
+      end
+
+      def singleton_unlock!
+        world.coordinator.release(singleton_lock)
+      end
+
+      def singleton_lock_class
+        ::Dynflow::Coordinator::SingletonActionLock
+      end
+
+      def singleton_lock
+        singleton_lock_class.new(self.class.name, execution_plan_id)
+      end
+
+      def error!(*args)
+        singleton_unlock!
+        super
+      end
+    end
+  end
+end

--- a/lib/dynflow/action/singleton.rb
+++ b/lib/dynflow/action/singleton.rb
@@ -1,6 +1,10 @@
 module Dynflow
   class Action
     module Singleton
+      def self.included(base)
+        base.middleware.use ::Dynflow::Middleware::Common::Singleton
+      end
+
       def validate_singleton_lock!
         singleton_lock! unless holds_singleton_lock?
       end

--- a/lib/dynflow/action/singleton.rb
+++ b/lib/dynflow/action/singleton.rb
@@ -5,7 +5,7 @@ module Dynflow
         singleton_lock!
         plan_self(*args)
       end
-      
+
       def run(event = nil)
         validate_singleton_lock!
       end

--- a/lib/dynflow/action/singleton.rb
+++ b/lib/dynflow/action/singleton.rb
@@ -1,27 +1,6 @@
 module Dynflow
   class Action
     module Singleton
-      def plan(*args)
-        singleton_lock!
-        plan_self(*args)
-      end
-
-      def run(event = nil)
-        # At the beginning of the run phase, verify we have the lock or fail
-        validate_singleton_lock!
-      end
-
-      def finalize
-        singleton_unlock!
-      end
-
-      private
-
-      def with_valid_singleton_lock
-        validate_singleton_lock!
-        yield
-      end
-
       def validate_singleton_lock!
         singleton_lock! unless holds_singleton_lock?
       end

--- a/lib/dynflow/coordinator.rb
+++ b/lib/dynflow/coordinator.rb
@@ -220,6 +220,27 @@ module Dynflow
       end
     end
 
+    # Used when there should be only one execution plan for a given action class
+    class SingletonActionLock < Lock
+      def initialize(action_class, execution_plan_id)
+        super
+        @data.merge!(owner_id: "execution-plan:#{execution_plan_id}", execution_plan_id: execution_plan_id)
+        @data[:id] = self.class.lock_id(action_class)
+      end
+
+      def owner_id
+        @data[:execution_plan_id]
+      end
+
+      def self.unique_filter(action_class)
+        { :class => self.name, :id => self.lock_id(action_class) }
+      end
+
+      def self.lock_id(action_class)
+        'singleton-action:' + action_class
+      end
+    end
+
     class ExecutionLock < LockByWorld
       def initialize(world, execution_plan_id, client_world_id, request_id)
         super(world)

--- a/lib/dynflow/coordinator.rb
+++ b/lib/dynflow/coordinator.rb
@@ -224,7 +224,8 @@ module Dynflow
     class SingletonActionLock < Lock
       def initialize(action_class, execution_plan_id)
         super
-        @data.merge!(owner_id: "execution-plan:#{execution_plan_id}", execution_plan_id: execution_plan_id)
+        @data[:owner_id] = "execution-plan:#{execution_plan_id}"
+        @data[:execution_plan_id] = execution_plan_id
         @data[:id] = self.class.lock_id(action_class)
       end
 

--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -117,6 +117,9 @@ module Dynflow
         @ended_at       = Time.now
         @real_time      = @ended_at - @started_at unless @started_at.nil?
         @execution_time = compute_execution_time
+        unlock_all_singleton_locks!
+      when :paused
+        unlock_all_singleton_locks!
       else
         # ignore
       end
@@ -254,6 +257,7 @@ module Dynflow
       if @run_flow.size == 1
         @run_flow = @run_flow.sub_flows.first
       end
+
       steps.values.each(&:save)
       update_state(error? ? :stopped : :planned)
     end
@@ -503,6 +507,10 @@ module Dynflow
         end
         hash
       end
+    end
+
+    def unlock_all_singleton_locks!
+      actions.select(&:holds_singleton_lock?).each(&:singleton_unlock!)
     end
 
     private_class_method :steps_from_hash

--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -510,7 +510,11 @@ module Dynflow
     end
 
     def unlock_all_singleton_locks!
-      actions.select(&:holds_singleton_lock?).each(&:singleton_unlock!)
+      filter = { :owner_id => 'execution-plan:' + self.id,
+                 :class => Dynflow::Coordinator::SingletonActionLock.to_s }
+      world.coordinator.find_locks(filter).each do |lock|
+        world.coordinator.release(lock)
+      end
     end
 
     private_class_method :steps_from_hash

--- a/lib/dynflow/middleware.rb
+++ b/lib/dynflow/middleware.rb
@@ -5,6 +5,7 @@ module Dynflow
     require 'dynflow/middleware/resolver'
     require 'dynflow/middleware/stack'
     require 'dynflow/middleware/common/transaction'
+    require 'dynflow/middleware/common/singleton'
 
     include Algebrick::TypeCheck
 

--- a/lib/dynflow/middleware/common/singleton.rb
+++ b/lib/dynflow/middleware/common/singleton.rb
@@ -7,37 +7,12 @@ module Dynflow
         pass(*args)
       end
 
-      # At the end of plan phase (after all actions were planned) we check
-      #   if the planning failed OR if the execution plan has no more steps to execute,
-      #   in which case we unlock all the locks
-      def plan_phase(execution_plan, *args)
-        pass(execution_plan, *args)
-        if execution_plan.result == :error || (execution_plan.run_steps.none? && execution_plan.finalize_steps.none?)
-          unlock_all_singleton_locks! execution_plan
-        end
-      end
-
       # At the start of #run we try to acquire action's lock unless it already holds it
       # At the end the action tries to unlock its own lock if the execution plan has no
       #   finalize phase
       def run(*args)
         action.singleton_lock! unless action.holds_singleton_lock?
         pass(*args)
-        action.singleton_unlock! if execution_plan.finalize_steps.none?
-      end
-
-      # At the end of finalize phase we check if the phase finished successfully,
-      #   in which case we unlock all the locks
-      def finalize_phase(execution_plan, *args)
-        pass(execution_plan, *args)
-        unlock_all_singleton_locks!(execution_plan) if execution_plan.finalize_steps.none?(&:error)
-      end
-
-      private
-
-      # Unlock all the singleton locks held by all actions belonging to this execution plan
-      def unlock_all_singleton_locks!(execution_plan)
-        execution_plan.actions.select(&:holds_singleton_lock?).each(&:singleton_unlock!)
       end
     end
   end

--- a/lib/dynflow/middleware/common/singleton.rb
+++ b/lib/dynflow/middleware/common/singleton.rb
@@ -4,7 +4,7 @@ module Dynflow
       def plan(*args)
         action.singleton_lock!
         pass(*args)
-        unless action.respond_to?(:run) || action.respond_to?(:finalize)  
+        unless action.respond_to?(:run) || action.respond_to?(:finalize)
           action.singleton_unlock!
         end
       end

--- a/lib/dynflow/middleware/common/singleton.rb
+++ b/lib/dynflow/middleware/common/singleton.rb
@@ -1,23 +1,43 @@
 module Dynflow
   module Middleware::Common
     class Singleton < Middleware
+      # Each action tries to acquire its own lock before the action's #plan starts
       def plan(*args)
         action.singleton_lock!
         pass(*args)
-        unless action.respond_to?(:run) || action.respond_to?(:finalize)
-          action.singleton_unlock!
+      end
+
+      # At the end of plan phase (after all actions were planned) we check
+      #   if the planning failed OR if the execution plan has no more steps to execute,
+      #   in which case we unlock all the locks
+      def plan_phase(execution_plan, *args)
+        pass(execution_plan, *args)
+        if execution_plan.result == :error || (execution_plan.run_steps.none? && execution_plan.finalize_steps.none?)
+          unlock_all_singleton_locks! execution_plan
         end
       end
 
+      # At the start of #run we try to acquire action's lock unless it already holds it
+      # At the end the action tries to unlock its own lock if the execution plan has no
+      #   finalize phase
       def run(*args)
         action.singleton_lock! unless action.holds_singleton_lock?
         pass(*args)
-        action.singleton_unlock! unless action.respond_to?(:finalize)
+        action.singleton_unlock! if execution_plan.finalize_steps.none?
       end
 
-      def finalize(*args)
-        pass(*args)
-        action.singleton_unlock!
+      # At the end of finalize phase we check if the phase finished successfully,
+      #   in which case we unlock all the locks
+      def finalize_phase(execution_plan, *args)
+        pass(execution_plan, *args)
+        unlock_all_singleton_locks!(execution_plan) if execution_plan.finalize_steps.none?(&:error)
+      end
+
+      private
+
+      # Unlock all the singleton locks held by all actions belonging to this execution plan
+      def unlock_all_singleton_locks!(execution_plan)
+        execution_plan.actions.select(&:holds_singleton_lock?).each(&:singleton_unlock!)
       end
     end
   end

--- a/lib/dynflow/middleware/common/singleton.rb
+++ b/lib/dynflow/middleware/common/singleton.rb
@@ -1,0 +1,24 @@
+module Dynflow
+  module Middleware::Common
+    class Singleton < Middleware
+      def plan(*args)
+        action.singleton_lock!
+        pass(*args)
+        unless action.respond_to?(:run) || action.respond_to?(:finalize)  
+          action.singleton_unlock!
+        end
+      end
+
+      def run(*args)
+        action.singleton_lock! unless action.holds_singleton_lock?
+        pass(*args)
+        action.singleton_unlock! unless action.respond_to?(:finalize)
+      end
+
+      def finalize(*args)
+        pass(*args)
+        action.singleton_unlock!
+      end
+    end
+  end
+end

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -299,11 +299,13 @@ module Dynflow
           logger.error "unexpected error when invalidating execution plan #{execution_lock.execution_plan_id}, skipping"
         end
         coordinator.release(execution_lock)
+        coordinator.release_by_owner(execution_lock.execution_plan_id)
         return
       end
       unless plan.valid?
         logger.error "invalid plan #{plan.id}, skipping"
         coordinator.release(execution_lock)
+        coordinator.release_by_owner(execution_lock.execution_plan_id)
         return
       end
       plan.execution_history.add('terminate execution', execution_lock.world_id)

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -741,9 +741,10 @@ module Dynflow
                               .unique_filter plan.entry_action.class.name
             world.coordinator.find_locks(lock_filter).count.must_equal 1
             future = world.execute(plan.id)
-            plan = world.persistence.load_execution_plan(plan.id)
-            plan.state.must_equal :running
-            plan.result.must_equal :pending
+            wait_for do
+              plan = world.persistence.load_execution_plan(plan.id)
+              plan.state == :running && plan.result == :pending
+            end
             world.coordinator.find_locks(lock_filter).count.must_equal 1
             world.event(plan.id, 2, nil)
             plan = future.wait!.value


### PR DESCRIPTION
An action into which this module is included (singleton action from
now on) on which there should be only one instance running at any
given time.

This means the action tries to obtain a lock at the beginning of its
plan phase and fails if it doesn't acquire it. At each Action#run it
checks if it is still holding the lock.  If it does, it goes on,
otherwise tries to reacquire it. It behaves the same way during the
lock reacquiring as in plan phase.

Finally, it releases the lock at the end of finalize phase. If
things go wrong, locks should get released when the execution plan
holding them gets invalidated.

Please make sure singleton actions release the lock they're holding
in case they encounter any error from which they can't recover.