### PR TITLE
Cache Ping messages

### DIFF
--- a/lib/dynflow/config.rb
+++ b/lib/dynflow/config.rb
@@ -113,6 +113,10 @@ module Dynflow
       true
     end
 
+    config_attr :announce, Algebrick::Types::Boolean do
+      true
+    end
+
     config_attr :auto_validity_check, Algebrick::Types::Boolean do |world, config|
       !!config.executor
     end

--- a/lib/dynflow/config.rb
+++ b/lib/dynflow/config.rb
@@ -98,11 +98,19 @@ module Dynflow
     end
 
     config_attr :executor, Executors::Abstract, FalseClass do |world, config|
-      Executors::Parallel.new(world, config.queues)
+      Executors::Parallel.new(world, config.executor_heartbeat_interval, config.queues)
     end
 
     config_attr :executor_semaphore, Semaphores::Abstract, FalseClass do |world, config|
       Semaphores::Dummy.new
+    end
+
+    config_attr :executor_heartbeat_interval, Integer do
+      15
+    end
+
+    config_attr :ping_cache_age, Integer do
+      60
     end
 
     config_attr :connector, Connectors::Abstract do |world|

--- a/lib/dynflow/config.rb
+++ b/lib/dynflow/config.rb
@@ -113,10 +113,6 @@ module Dynflow
       true
     end
 
-    config_attr :announce, Algebrick::Types::Boolean do
-      true
-    end
-
     config_attr :auto_validity_check, Algebrick::Types::Boolean do |world, config|
       !!config.executor
     end

--- a/lib/dynflow/connectors/abstract.rb
+++ b/lib/dynflow/connectors/abstract.rb
@@ -27,7 +27,6 @@ module Dynflow
         match(envelope.message,
               (on Dispatcher::Ping do
                  response_envelope = envelope.build_response_envelope(Dispatcher::Pong, world)
-                 world.client_dispatcher.tell([:add_ping_cache_record, envelope.sender_id])
                  send(response_envelope)
                end),
               (on Dispatcher::Request do

--- a/lib/dynflow/connectors/abstract.rb
+++ b/lib/dynflow/connectors/abstract.rb
@@ -27,6 +27,7 @@ module Dynflow
         match(envelope.message,
               (on Dispatcher::Ping do
                  response_envelope = envelope.build_response_envelope(Dispatcher::Pong, world)
+                 world.client_dispatcher.tell([:add_ping_cache_record, envelope.sender_id])
                  send(response_envelope)
                end),
               (on Dispatcher::Request do

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -28,6 +28,7 @@ module Dynflow
 
       class PingCache
         TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%L'
+        PING_CACHE_AGE = 10
 
         def self.format_time(time = Time.now)
           time.strftime(TIME_FORMAT)
@@ -37,9 +38,8 @@ module Dynflow
           Time.strptime(time, TIME_FORMAT)
         end
 
-        def initialize(world, age = 10)
+        def initialize(world)
           @world = world
-          @max_age = age
         end
 
         def add_record(id, time = Time.now)
@@ -52,7 +52,7 @@ module Dynflow
           record = find_world(id)
           return false if record.nil?
           time = self.class.load_time(record.data[:meta][:last_seen])
-          time >= Time.now - @max_age
+          time >= Time.now - PING_CACHE_AGE
         end
 
         private

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -42,9 +42,9 @@ module Dynflow
           @max_age = age
         end
 
-        def add_record(id)
+        def add_record(id, time = Time.now)
           record = find_world id
-          record.data[:meta].update(:last_seen => self.class.format_time)
+          record.data[:meta].update(:last_seen => self.class.format_time(time))
           @world.coordinator.update_record(record)
         end
 

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -34,6 +34,7 @@ module Dynflow
       class PingCache
         # Format string used for formating and parsing times
         TIME_FORMAT = '%Y-%m-%d %H:%M:%S.%L'.freeze
+        DEFAULT_MAX_AGE = 60
 
         # Formats time into a string
         #
@@ -52,7 +53,7 @@ module Dynflow
         end
 
         # @param world [World] the world to which the PingCache belongs
-        def initialize(world, max_age)
+        def initialize(world, max_age = DEFAULT_MAX_AGE)
           @world = world
           @max_age = max_age
           @executor = {}

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -74,11 +74,9 @@ module Dynflow
         # @param id [String] Id of the world
         # @return [TrueClass] if the world has an executor
         # @return [FalseClass] if the world is a client world
+        # @return [NilClass] if unknown
         def executor?(id)
-          return @executor[id] unless @executor[id].nil?
-          record = find_world id
-          return false if record.nil?
-          @executor[id] = record.data[:class] == 'Dynflow::Coordinator::ExecutorWorld'
+          @executor[id]
         end
 
         # Loads the coordinator record from the database and checks whether the world
@@ -90,6 +88,7 @@ module Dynflow
         def fresh_record?(id)
           record = find_world(id)
           return false if record.nil?
+          @executor[id] = record.data[:class] == 'Dynflow::Coordinator::ExecutorWorld'
           time = self.class.load_time(record.data[:meta][:last_seen])
           time >= Time.now - @max_age
         end

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -77,7 +77,10 @@ module Dynflow
         # @return [TrueClass] if the world has an executor
         # @return [FalseClass] if the world is a client world
         def executor?(id)
-          @executor[id]
+          return @executor[id] unless @executor[id].nil?
+          record = find_world id
+          return false if record.nil?
+          @executor[id] = record.data[:class] == 'Dynflow::Coordinator::ExecutorWorld'
         end
 
         # Loads the coordinator record from the database and checks whether the world

--- a/lib/dynflow/executors/parallel.rb
+++ b/lib/dynflow/executors/parallel.rb
@@ -5,10 +5,10 @@ module Dynflow
       require 'dynflow/executors/parallel/pool'
       require 'dynflow/executors/parallel/worker'
 
-      def initialize(world, queues_options = { :default => { :pool_size => 5 }})
+      def initialize(world, heartbeat_interval, queues_options = { :default => { :pool_size => 5 }})
         super(world)
         @core = Core.spawn name:        'parallel-executor-core',
-                           args:        [world, queues_options],
+                           args:        [world, heartbeat_interval, queues_options],
                            initialized: @core_initialized = Concurrent.future
       end
 

--- a/lib/dynflow/executors/parallel/core.rb
+++ b/lib/dynflow/executors/parallel/core.rb
@@ -4,15 +4,14 @@ module Dynflow
       class Core < Actor
         attr_reader :logger
 
-        HEARTBEAT_INTERVAL = 15
-
-        def initialize(world, queues_options)
+        def initialize(world, heartbeat_interval, queues_options)
           @logger         = world.logger
           @world          = Type! world, World
           @queues_options = queues_options
           @pools          = {}
           @terminated     = nil
           @director       = Director.new(@world)
+          @heartbeat_interval = heartbeat_interval
 
           initialize_queues
           schedule_heartbeat
@@ -93,7 +92,7 @@ module Dynflow
         private
 
         def schedule_heartbeat
-          @world.clock.ping(self, HEARTBEAT_INTERVAL, :heartbeat)
+          @world.clock.ping(self, @heartbeat_interval, :heartbeat)
         end
 
         def on_message(message)

--- a/lib/dynflow/rails/configuration.rb
+++ b/lib/dynflow/rails/configuration.rb
@@ -155,7 +155,9 @@ module Dynflow
         if remote?
           false
         else
-          ::Dynflow::Executors::Parallel.new(world, world.config.queues)
+          ::Dynflow::Executors::Parallel.new(world,
+                                             world.config.executor_heartbeat_interval,
+                                             world.config.queues)
         end
       end
 

--- a/lib/dynflow/web/console.rb
+++ b/lib/dynflow/web/console.rb
@@ -50,16 +50,14 @@ module Dynflow
       end
 
       post('/worlds/check') do
-        load_worlds
         @validation_results = world.worlds_validity_check(params[:invalidate])
-        @worlds = world.coordinator.find_worlds
+        load_worlds
         erb :worlds
       end
 
       post('/worlds/:id/check') do |id|
-        load_worlds
         @validation_results = world.worlds_validity_check(params[:invalidate], id: params[:id])
-        @worlds = world.coordinator.find_worlds
+        load_worlds
         erb :worlds
       end
 

--- a/lib/dynflow/web/console.rb
+++ b/lib/dynflow/web/console.rb
@@ -52,12 +52,14 @@ module Dynflow
       post('/worlds/check') do
         load_worlds
         @validation_results = world.worlds_validity_check(params[:invalidate])
+        @worlds = world.coordinator.find_worlds
         erb :worlds
       end
 
       post('/worlds/:id/check') do |id|
         load_worlds
         @validation_results = world.worlds_validity_check(params[:invalidate], id: params[:id])
+        @worlds = world.coordinator.find_worlds
         erb :worlds
       end
 

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -49,6 +49,7 @@ module Dynflow
       @meta['queues']           = @config.queues if @executor
       @meta['delayed_executor'] = true if @delayed_executor
       @meta['execution_plan_cleaner'] = true if @execution_plan_cleaner
+      @meta['last_seen'] = Dynflow::Dispatcher::ClientDispatcher::PingCache.format_time
       coordinator.register_world(registered_world)
       @termination_barrier = Mutex.new
       @before_termination_hooks = Queue.new
@@ -61,7 +62,6 @@ module Dynflow
       end
       self.auto_execute if @config.auto_execute
       @delayed_executor.start if @delayed_executor
-      announce if config_for_world.announce
     end
 
     def before_termination(&block)
@@ -432,13 +432,6 @@ module Dynflow
         rescue => e
           logger.error e
         end
-      end
-    end
-
-    def announce
-      coordinator.find_worlds(false).each do |world|
-        # Ping all the other worlds
-        ping(world.id, self.validity_check_timeout) unless world.id == self.id
       end
     end
 

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -28,7 +28,7 @@ module Dynflow
       @connector              = @config.connector
       @middleware             = Middleware::World.new
       @middleware.use Middleware::Common::Transaction if @transaction_adapter
-      @client_dispatcher      = spawn_and_wait(Dispatcher::ClientDispatcher, "client-dispatcher", self)
+      @client_dispatcher      = spawn_and_wait(Dispatcher::ClientDispatcher, "client-dispatcher", self, @config.ping_cache_age)
       @dead_letter_handler    = spawn_and_wait(DeadLetterSilencer, 'default_dead_letter_handler', @config.silent_dead_letter_matchers)
       @auto_validity_check    = @config.auto_validity_check
       @validity_check_timeout = @config.validity_check_timeout

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -61,6 +61,7 @@ module Dynflow
       end
       self.auto_execute if @config.auto_execute
       @delayed_executor.start if @delayed_executor
+      announce if config_for_world.announce
     end
 
     def before_termination(&block)
@@ -431,6 +432,13 @@ module Dynflow
         rescue => e
           logger.error e
         end
+      end
+    end
+
+    def announce
+      coordinator.find_worlds(false).each do |world|
+        # Ping all the other worlds
+        ping(world.id, self.validity_check_timeout) unless world.id == self.id
       end
     end
 

--- a/test/abnormal_states_recovery_test.rb
+++ b/test/abnormal_states_recovery_test.rb
@@ -194,7 +194,7 @@ module Dynflow
             client_world_config = Config::ForWorld.new(Config.new.tap { |c| c.executor = false }, create_world )
             client_world_config.auto_validity_check.must_equal false
 
-            executor_world_config = Config::ForWorld.new(Config.new.tap { |c| c.executor = lambda { |w, _| Executors::Parallel.new(w) } }, create_world )
+            executor_world_config = Config::ForWorld.new(Config.new.tap { |c| c.executor = lambda { |w, _| Executors::Parallel.new(w, 15) } }, create_world )
             executor_world_config.auto_validity_check.must_equal true
           end
 

--- a/test/dispatcher_test.rb
+++ b/test/dispatcher_test.rb
@@ -90,21 +90,13 @@ module Dynflow
 
             ping_cache = Dynflow::Dispatcher::ClientDispatcher::PingCache.new(executor_world)
 
+            # Records are fresh because of the heartbeat
             assert ping_cache.fresh_record?(client_world.id)
             assert ping_cache.fresh_record?(executor_world.id)
 
             # Expire the record
             ping_cache.add_record(executor_world.id, Time.now - 1000)
-
             refute ping_cache.fresh_record?(executor_world.id)
-            ping_response = client_world.ping(executor_world.id, 0.5)
-            ping_response.wait
-            assert ping_response.success?
-            assert ping_cache.fresh_record?(executor_world.id)
-
-            ping_response = client_world.ping(executor_world.id, 0)
-            ping_response.wait
-            assert ping_response.success?
           end
         end
       end

--- a/test/dispatcher_test.rb
+++ b/test/dispatcher_test.rb
@@ -82,6 +82,21 @@ module Dynflow
             ping_response.wait
             assert ping_response.failed?
           end
+
+          it 'caches the pings and pongs' do
+            ping_response = client_world.ping(executor_world.id, 0.5)
+            ping_response.wait
+            assert ping_response.success?
+            client_cache = client_world.client_dispatcher.ask!(:ping_cache)
+            # Client now has fresh record for executor
+            assert client_cache.fresh_record?(executor_world.id)
+            executor_cache = executor_world.client_dispatcher.ask!(:ping_cache)
+            # Executor now has fresh record for client
+            assert executor_cache.fresh_record?(client_world.id)
+            ping_response = client_world.ping(executor_world.id, 0)
+            ping_response.wait
+            assert ping_response.success?
+          end
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -96,7 +96,6 @@ module WorldFactory
     config.backup_deleted_plans = false
     config.backup_dir           = nil
     config.queues.add(:slow, :pool_size => 1)
-    config.announce             = false
     yield config if block_given?
     return config
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -96,6 +96,7 @@ module WorldFactory
     config.backup_deleted_plans = false
     config.backup_dir           = nil
     config.queues.add(:slow, :pool_size => 1)
+    config.announce             = false
     yield config if block_given?
     return config
   end

--- a/test/world_test.rb
+++ b/test/world_test.rb
@@ -48,34 +48,6 @@ module Dynflow
           terminated_event.completed?.must_equal true
         end
       end
-
-      describe '#announce' do
-        include TestHelpers
-
-        let(:persistence_adapter) { WorldFactory.persistence_adapter }
-        let(:shared_connector) { Connectors::Direct.new() }
-        let(:connector) { Proc.new { |world| shared_connector.start_listening(world); shared_connector } }
-        let(:announce_world) do
-          create_world(false) { |config| config.announce = true }
-        end
-        let(:world) { create_world(false) }
-
-        it 'announces its availability on creation' do
-          # The test worlds are set not to announce themselves
-          world
-
-          # Force creation of another world
-          announce_world
-
-          # Both world should have each other's records in cache when the messages get delivered
-          wait_for do
-            cache = world.client_dispatcher.ask!(:ping_cache)
-            announce_cache = announce_world.client_dispatcher.ask!(:ping_cache)
-            cache.fresh_record?(announce_world.id) &&
-              announce_cache.fresh_record?(world.id)
-          end
-        end
-      end
     end
   end
 end

--- a/test/world_test.rb
+++ b/test/world_test.rb
@@ -10,6 +10,7 @@ module Dynflow
       describe '#meta' do
         it 'by default informs about the hostname and the pid running the world' do
           registered_world = world.coordinator.find_worlds(false, id: world.id).first
+          registered_world.meta.delete('last_seen')
           registered_world.meta.must_equal('hostname' => Socket.gethostname, 'pid' => Process.pid,
                                            'queues' => { 'default' => { 'pool_size' => 5 },
                                                          'slow' => { 'pool_size' => 1 }})

--- a/test/world_test.rb
+++ b/test/world_test.rb
@@ -48,6 +48,34 @@ module Dynflow
           terminated_event.completed?.must_equal true
         end
       end
+
+      describe '#announce' do
+        include TestHelpers
+
+        let(:persistence_adapter) { WorldFactory.persistence_adapter }
+        let(:shared_connector) { Connectors::Direct.new() }
+        let(:connector) { Proc.new { |world| shared_connector.start_listening(world); shared_connector } }
+        let(:announce_world) do
+          create_world(false) { |config| config.announce = true }
+        end
+        let(:world) { create_world(false) }
+
+        it 'announces its availability on creation' do
+          # The test worlds are set not to announce themselves
+          world
+
+          # Force creation of another world
+          announce_world
+
+          # Both world should have each other's records in cache when the messages get delivered
+          wait_for do
+            cache = world.client_dispatcher.ask!(:ping_cache)
+            announce_cache = announce_world.client_dispatcher.ask!(:ping_cache)
+            cache.fresh_record?(announce_world.id) &&
+              announce_cache.fresh_record?(world.id)
+          end
+        end
+      end
     end
   end
 end

--- a/web/views/worlds.erb
+++ b/web/views/worlds.erb
@@ -9,7 +9,8 @@
 <h3>Executors</h3>
 <% @executors.each do |world| %>
   <%= value_field('Id', world.id) %>
-  <%= value_field('Metadata', world.meta) %>
+  <%= value_field('Metadata', world.meta.reject { |key, _| key == 'last_seen' }) %>
+  <%= value_field('Last seen', world.meta['last_seen']) %>
   <p>
     <b>Status:</b>
     <%= erb :world_validation_result, locals: { world: world } %>
@@ -39,13 +40,15 @@
     <tr>
       <th>Id</th>
       <th>Meta</th>
+      <th>Last seen</th>
       <th></th>
     </tr>
   </thead>
 <% @clients.each do |world| %>
   <tr>
     <td><%= h(world.id) %></td>
-    <td><%= h(world.meta) %></td>
+    <td><%= h(world.meta.reject { |key, _| key == 'last_seen' }) %></td>
+    <td><%= h(world.meta[:last_seen]) %></td>
     <td>
       <%= erb :world_validation_result, locals: { world: world } %>
     </td>


### PR DESCRIPTION
Some other projects use Pings quite extensively (run them at the start
of every actions) so it seemed like a good idea to cache them to reduce
the number of sent messages.

This commit introduces such mechanism. Cache records are added either
when a response to a Ping or a Ping is received. This way, both
participants in the communication have the other one in their own
caches.

Furthermore a world tries to announce its availability (pings all other
worlds) at the end of its #initialize.