### PR TITLE
Add support for makara adapter

### DIFF
--- a/lib/dynflow/rails/configuration.rb
+++ b/lib/dynflow/rails/configuration.rb
@@ -118,6 +118,7 @@ module Dynflow
 
       def default_sequel_adapter_options
         db_config            = ::ActiveRecord::Base.configurations[::Rails.env].dup
+        db_config['adapter'] = db_config['adapter'].gsub(/_?makara_?/, '')
         db_config['adapter'] = 'postgres' if db_config['adapter'] == 'postgresql'
         db_config['max_connections'] = db_pool_size if increase_db_pool_size?
 


### PR DESCRIPTION
Makara can be used as a wrapper around the standar ActiveRecord adapter.
This patch should allow users using Dynflow while using this adapter.

See [1] for such an example.

[1] - https://groups.google.com/d/msg/foreman-users/ORak_xvLi-U/Qy56C3SSAAAJ