### PR TITLE
change logging level for failed actions

### DIFF
--- a/lib/dynflow/delayed_executors/abstract_core.rb
+++ b/lib/dynflow/delayed_executors/abstract_core.rb
@@ -38,7 +38,7 @@ module Dynflow
       def with_error_handling(error_retval = nil, &block)
         block.call
       rescue Exception => e
-        @logger.fatal e.backtrace.join("\n")
+        @logger.warn e.backtrace.join("\n")
         error_retval
       end
 

--- a/lib/dynflow/delayed_executors/abstract_core.rb
+++ b/lib/dynflow/delayed_executors/abstract_core.rb
@@ -38,7 +38,8 @@ module Dynflow
       def with_error_handling(error_retval = nil, &block)
         block.call
       rescue Exception => e
-        @logger.warn e.backtrace.join("\n")
+        @logger.warn e.message
+        @logger.debug e.backtrace.join("\n")
         error_retval
       end
 


### PR DESCRIPTION
in many cases, I'm seeing trace in the logs where they are not required, for example:
* ERROR -- /executor-dispatcher: ActiveRecord::ConnectionNotEstablished (ActiveRecord::ConnectionNotEstablished)
* invalid worlds found {..}
* /home/foreman/gems/gems/dynflow-0.8.34/lib/dynflow/stateful.rb:35:in `set_state'

while the first two are clear for me, I think the last one is missing printing out the actual exception, but probably can be fixed in another pr.
I'm suggesting to change to WARN so users can change their log level and see the trace, but by default it doesn't log in production the full trace.