### PR TITLE
Pin minitest to -> 5.10.0

### DIFF
--- a/dynflow.gemspec
+++ b/dynflow.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rack-test"
-  s.add_development_dependency "minitest"
+  s.add_development_dependency "minitest", '~> 5.10.0'
   s.add_development_dependency "minitest-reporters"
   s.add_development_dependency "activerecord"
   s.add_development_dependency 'activejob'


### PR DESCRIPTION
There is an issue with minitest 5.11.x + Rails 5.1. It should be fixed
in Rails (https://github.com/rails/rails/pull/30800), however, it's not
released yet.

5.11.x gives us issues described in
https://github.com/seattlerb/minitest/issues/730.