### PR TITLE
Disable minitest plugins

### DIFF
--- a/dynflow.gemspec
+++ b/dynflow.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rack-test"
-  s.add_development_dependency "minitest", '~> 5.10.0'
+  s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-reporters"
   s.add_development_dependency "activerecord"
   s.add_development_dependency 'activejob'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 require 'minitest/reporters'
 require 'minitest/autorun'
 require 'minitest/spec'
+ENV['MT_NO_PLUGINS'] = 'true'
 
 MiniTest::Reporters.use! if ENV['RM_INFO']
 


### PR DESCRIPTION
In 35efa3bdc9d1324709bc2200b0f6a42a85cc1f54, we've pinned the minitest
version because the new version was not compatible with the Rails
minitest plugin.

I've noticed also, that the Rails plugin does other non-standard things,
such as printing the test errors inline, as opposed to at the end of the
test run. This was not working nicely, as currently, our tests are quite
verbose at the output.

Putting the fact that we should be less verbose at the test run, I don't
like the behavior the Rails introduces and there is no nice way how to
disable this behavior, when defining the test Rake task.

Together with the fact, that Rails is currently broken with minitest
5.11.x, disabling autoloading of the minitest plugins seems like the
best thing we can do.

The disabling was introduced in
https://github.com/seattlerb/minitest/commit/b84b8176930bacb4d70d6bef476b1ea0f7c94977