### PR TITLE
Fix NaN as progress value for WithBulkSubPlans

### DIFF
--- a/lib/dynflow/action/with_bulk_sub_plans.rb
+++ b/lib/dynflow/action/with_bulk_sub_plans.rb
@@ -58,7 +58,7 @@ module Dynflow
 
     # The same logic as in Action::WithSubPlans, but calculated using the expected total count
     def run_progress
-      if counts_set?
+      if counts_set? && total_count > 0
         sum = output.values_at(:success_count, :cancelled_count, :failed_count).reduce(:+)
         sum.to_f / total_count
       else

--- a/lib/dynflow/execution_plan/steps/abstract.rb
+++ b/lib/dynflow/execution_plan/steps/abstract.rb
@@ -154,10 +154,18 @@ module Dynflow
         @started_at ||= start
         block.call
       ensure
-        @progress_done, @progress_weight = action.calculated_progress
+        calculate_progress(action)
         @ended_at        = Time.now
         @execution_time += @ended_at - start
         @real_time       = @ended_at - @started_at
+      end
+
+      def calculate_progress(action)
+        @progress_done, @progress_weight = action.calculated_progress
+        if @progress_done.is_a?(Float) && !@progress_done.finite?
+          action_logger.error("Unexpected progress value #{@progress_done} for step #{execution_plan_id}##{id}")
+          @progress_done = 0
+        end
       end
     end
   end

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -628,8 +628,8 @@ module Dynflow
             total = 2
             plan = world.plan(PollingParentAction, count: total)
             plan.state.must_equal :planned
-            world.execute(plan.id)
             clock.pending_pings.count.must_equal 0
+            world.execute(plan.id)
             wait_for do
               plan.sub_plans_count == total &&
                 plan.sub_plans.all? { |sub| sub.result == :success }

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -619,6 +619,7 @@ module Dynflow
 
       describe ::Dynflow::Action::WithPollingSubPlans do
         include TestHelpers
+        include Testing
 
         let(:clock) { Dynflow::Testing::ManagedClock.new }
 
@@ -672,6 +673,11 @@ module Dynflow
             plan.entry_action.output[:poll].must_equal 1
             clock.pending_pings.count.must_equal 0
           end
+        end
+
+        it 'handles empty sub plans when calculating progress' do
+          action = create_and_plan_action(PollingBulkParentAction, :count => 0)
+          action.run_progress.must_equal 0.1
         end
 
         describe ::Dynflow::Action::Singleton do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -193,8 +193,10 @@ module TestHelpers
       executor_id_for_plan(triggered.id)
     end
 
+    plan = client_world.persistence.load_execution_plan(triggered.id)
+    step = plan.steps.values.last
     wait_for do
-      client_world.persistence.load_execution_plan(triggered.id).state == :running
+      client_world.persistence.load_step(step.execution_plan_id, step.id, client_world).state == :suspended
     end
 
     executor = WorldFactory.created_worlds.find { |e| e.id == executor_id }


### PR DESCRIPTION
In case of empty set of sub plans, the aciont with WithBulkSubPlans was
calculating progress as 0./0, which lead to NaN. While some
databases (such as Postgres), were converting this value to 0, on
SQLite, we were getting:

  Sequel::DatabaseError: SQLite3::SQLException: no such column: NaN

The code fixes the WithBulkSubPlans progress calculation + ensuring that
we handle unexpected progress value better.