### PR TITLE
Reduce the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,23 @@ language:
   - ruby
 
 rvm:
-  - "2.0.0"
-  - "2.1.5"
-  - "2.2.0"
+  - "2.2.2"
   - "2.3.1"
   - "2.4.0"
+  - "2.5.0"
 
 env:
   global:
-    - "TESTOPTS=--verbose"
-  matrix:
-    - "DB=mysql DB_CONN_STRING=mysql2://root@localhost/travis_ci_test CONCURRENT_RUBY_EXT=true"
-    - "DB=postgresql DB_CONN_STRING=postgres://postgres@localhost/travis_ci_test CONCURRENT_RUBY_EXT=true"
-    - "DB=sqlite3 CONCURRENT_RUBY_EXT=true"
-    - "DB=mysql DB_CONN_STRING=mysql2://root@localhost/travis_ci_test CONCURRENT_RUBY_EXT=false"
-    - "DB=postgresql DB_CONN_STRING=postgres://postgres@localhost/travis_ci_test CONCURRENT_RUBY_EXT=false"
-    - "DB=sqlite3 CONCURRENT_RUBY_EXT=false"
+    - "TESTOPTS=--verbose DB=postgresql DB_CONN_STRING=postgres://postgres@localhost/travis_ci_test"
+
+matrix:
+  include:
+    - rvm: "2.4.0"
+      env: "DB=mysql DB_CONN_STRING=mysql2://root@localhost/travis_ci_test"
+    - rvm: "2.4.0"
+      env: "DB=sqlite3 DB_CONN_STRING=sqlite:/"
+    - rvm: "2.4.0"
+      env: "CONCURRENT_RUBY_EXT=true"
 
 install:
   - test/prepare_travis_env.sh


### PR DESCRIPTION
Run different databases only on the newest ruby version. Use postgres by
default.