### PR TITLE
Use UUID column type on PostgreSQL

### DIFF
--- a/lib/dynflow/persistence_adapters/sequel_migrations/011_add_uuid_column.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/011_add_uuid_column.rb
@@ -1,0 +1,61 @@
+def to_uuid(table_name, column_name)
+  set_column_type(table_name, column_name, :uuid, :using => "#{column_name}::uuid")
+end
+
+def from_uuid(table_name, column_name)
+  set_column_type table_name, column_name, String, primary_key: true, size: 36, fixed: true
+end
+
+def with_foreign_key_recreation(&block)
+  # Drop the foreign key constraints so we can change the column type
+  alter_table :dynflow_actions do
+    drop_foreign_key [:execution_plan_uuid]
+  end
+  alter_table :dynflow_steps do
+    drop_foreign_key [:execution_plan_uuid]
+    drop_foreign_key [:execution_plan_uuid, :action_id], :name => :dynflow_steps_execution_plan_uuid_fkey1
+  end
+  alter_table :dynflow_delayed_plans do
+    drop_foreign_key [:execution_plan_uuid]
+  end
+
+  block.call
+
+  # Recreat the foreign key constraints as they were before
+  alter_table :dynflow_actions do
+    add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans
+  end
+  alter_table :dynflow_steps do
+    add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans
+    add_foreign_key [:execution_plan_uuid, :action_id], :dynflow_actions,
+      :name => :dynflow_steps_execution_plan_uuid_fkey1
+  end
+  alter_table :dynflow_delayed_plans do
+    add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans,
+      :name => :dynflow_scheduled_plans_execution_plan_uuid_fkey
+  end
+end
+
+Sequel.migration do
+  up do
+    if database_type == :postgresql
+      with_foreign_key_recreation do
+        to_uuid :dynflow_execution_plans, :uuid
+        to_uuid :dynflow_actions,         :execution_plan_uuid
+        to_uuid :dynflow_steps,           :execution_plan_uuid
+        to_uuid :dynflow_delayed_plans,   :execution_plan_uuid
+      end
+    end
+  end
+
+  down do
+    if database_type == :postgresql
+      with_foreign_key_recreation do
+        from_uuid :dynflow_execution_plans, :uuid
+        from_uuid :dynflow_actions,         :execution_plan_uuid
+        from_uuid :dynflow_steps,           :execution_plan_uuid
+        from_uuid :dynflow_delayed_plans,   :execution_plan_uuid
+      end
+    end
+  end
+end

--- a/lib/dynflow/persistence_adapters/sequel_migrations/011_add_uuid_column.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/011_add_uuid_column.rb
@@ -28,11 +28,11 @@ def with_foreign_key_recreation(&block)
   alter_table :dynflow_steps do
     add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans
     add_foreign_key [:execution_plan_uuid, :action_id], :dynflow_actions,
-      :name => :dynflow_steps_execution_plan_uuid_fkey1
+                    :name => :dynflow_steps_execution_plan_uuid_fkey1
   end
   alter_table :dynflow_delayed_plans do
     add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans,
-      :name => :dynflow_scheduled_plans_execution_plan_uuid_fkey
+                    :name => :dynflow_scheduled_plans_execution_plan_uuid_fkey
   end
 end
 


### PR DESCRIPTION
Dynflow DB with 20002 execution plans, consisting of 100002 actions and 200004 steps.

| | execution_plans | actions | steps
|-| -----------------:|---------:|--------:|
as string | 27 MB | 91 MB | 197 MB
as uuid | 24 MB | 59 MB | 127 MB
change | -3 MB | -32 MB | -70 MB

Gist showing change in schema: https://gist.github.com/adamruzicka/7630827c1be46a741cc2b453bfdb8c20/revisions#diff-39859e34161f0cb6f5f50974282a2593