### PR TITLE
Fixes #22837 - postpone validation checks in Rails environment

### DIFF
--- a/lib/dynflow/rails.rb
+++ b/lib/dynflow/rails.rb
@@ -41,6 +41,7 @@ module Dynflow
           config.run_on_init_hooks(world)
           # leave this just for long-running executors
           unless config.rake_task_with_executor?
+            world.perform_validity_checks
             world.auto_execute
           end
         end

--- a/lib/dynflow/rails/configuration.rb
+++ b/lib/dynflow/rails/configuration.rb
@@ -111,6 +111,7 @@ module Dynflow
 
           # we can't do any operation until the Rails.application.dynflow.world is set
           config.auto_execute        = false
+          config.auto_validity_check = false
         end
       end
 

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -42,10 +42,8 @@ module Dynflow
         @executor_dispatcher = spawn_and_wait(Dispatcher::ExecutorDispatcher, "executor-dispatcher", self, config_for_world.executor_semaphore)
         executor.initialized.wait
       end
-      if auto_validity_check
-        self.worlds_validity_check
-        self.locks_validity_check
-      end
+      perform_validity_checks if auto_validity_check
+
       @delayed_executor         = try_spawn(config_for_world, :delayed_executor, Coordinator::DelayedExecutorLock)
       @execution_plan_cleaner   = try_spawn(config_for_world, :execution_plan_cleaner, Coordinator::ExecutionPlanCleanerLock)
       @meta                     = config_for_world.meta
@@ -335,6 +333,11 @@ module Dynflow
       end
     rescue Errors::PersistenceError
       logger.error "failed to write data while invalidating execution lock #{execution_lock}"
+    end
+
+    def perform_validity_checks
+      worlds_validity_check
+      locks_validity_check
     end
 
     def worlds_validity_check(auto_invalidate = true, worlds_filter = {})

--- a/test/daemon_test.rb
+++ b/test/daemon_test.rb
@@ -16,6 +16,7 @@ class DaemonTest < ActiveSupport::TestCase
     @world_class = mock('dummy world factory')
     @dummy_world = ::Dynflow::Testing::DummyWorld.new
     @dummy_world.stubs(:auto_execute)
+    @dummy_world.stubs(:perform_validity_checks)
     @event = Concurrent.event
     @dummy_world.stubs(:terminated).returns(@event)
     @world_class.stubs(:new).returns(@dummy_world)


### PR DESCRIPTION
Otherwise, the actions performed during the validity check could lead to
issues like this:

    RuntimeError: The Dynflow world was not initialized yet. If your plugin
    uses it, make sure to call Rails.application.dynflow.require! in some
    initializer