### PR TITLE
Fixes #22839 - defensive cleanup when running user-defined code

### DIFF
--- a/lib/dynflow/delayed_executors/abstract_core.rb
+++ b/lib/dynflow/delayed_executors/abstract_core.rb
@@ -52,8 +52,10 @@ module Dynflow
               plan.timeout
             else
               @logger.debug "Executing plan #{plan.execution_plan_uuid}"
-              plan.plan
-              plan.execute
+              Executors.run_user_code do
+                plan.plan
+                plan.execute
+              end
             end
             processed_plan_uuids << plan.execution_plan_uuid
           end

--- a/lib/dynflow/execution_plan/hooks.rb
+++ b/lib/dynflow/execution_plan/hooks.rb
@@ -60,12 +60,16 @@ module Dynflow
         # @param action [Action] the action which triggered the hooks
         # @param kind [Symbol] the kind of hooks to run, one of {HOOK_KINDS}
         def run(execution_plan, action, kind)
-          on(kind).each do |hook|
-            begin
-              action.send(hook, execution_plan)
-            rescue => e
-              execution_plan.logger.error "Failed to run hook '#{hook}' for action '#{action.class}'"
-              execution_plan.logger.debug e
+          hooks = on(kind)
+          return if hooks.empty?
+          Executors.run_user_code do
+            hooks.each do |hook|
+              begin
+                action.send(hook, execution_plan)
+              rescue => e
+                execution_plan.logger.error "Failed to run hook '#{hook}' for action '#{action.class}'"
+                execution_plan.logger.debug e
+              end
             end
           end
         end

--- a/lib/dynflow/executors.rb
+++ b/lib/dynflow/executors.rb
@@ -4,5 +4,14 @@ module Dynflow
     require 'dynflow/executors/abstract'
     require 'dynflow/executors/parallel'
 
+    # Every time we run a code that can be defined outside of Dynflow,
+    # we should wrap it with this method, and we can ensure here to do
+    # necessary cleanup, such as cleaning ActiveRecord connections
+    def self.run_user_code
+      yield
+    ensure
+      ::ActiveRecord::Base.clear_active_connections! if defined? ::ActiveRecord
+    end
+
   end
 end

--- a/lib/dynflow/executors/parallel/worker.rb
+++ b/lib/dynflow/executors/parallel/worker.rb
@@ -8,12 +8,13 @@ module Dynflow
         end
 
         def on_message(work_item)
-          work_item.execute
+          Executors.run_user_code do
+            work_item.execute
+          end
         rescue Errors::PersistenceError => e
           @pool.tell([:handle_persistence_error, e])
         ensure
           @pool.tell([:worker_done, reference, work_item])
-          @transaction_adapter.cleanup
         end
       end
     end

--- a/lib/dynflow/transaction_adapters/abstract.rb
+++ b/lib/dynflow/transaction_adapters/abstract.rb
@@ -10,12 +10,6 @@ module Dynflow
       def rollback
         raise NotImplementedError
       end
-
-      # Called on each thread after work is done.
-      # E.g. it's used to checkin ActiveRecord connections back to pool.
-      def cleanup
-        # override if needed
-      end
     end
   end
 end

--- a/lib/dynflow/transaction_adapters/active_record.rb
+++ b/lib/dynflow/transaction_adapters/active_record.rb
@@ -8,10 +8,6 @@ module Dynflow
       def rollback
         raise ::ActiveRecord::Rollback
       end
-
-      def cleanup
-        ::ActiveRecord::Base.clear_active_connections!
-      end
     end
   end
 end


### PR DESCRIPTION
In case we run user code inside Dynflow threads, we should make sure to
clean common mess, such as leaking ActiveRecord connections.