### PR TITLE
Fixes #23156 - handle unexpected plan states

### DIFF
--- a/test/future_execution_test.rb
+++ b/test/future_execution_test.rb
@@ -25,6 +25,20 @@ module Dynflow
         end
         let(:execution_plan) { delayed_plan.execution_plan }
 
+        describe 'abstract executor' do
+          let(:abstract_delayed_executor) { DelayedExecutors::AbstractCore.new(world) }
+
+          it 'handles wrong plan state' do
+            delayed_plan.execution_plan.state = :planning
+            abstract_delayed_executor.send(:process, [delayed_plan], @start_at)
+            delayed_plan.execution_plan.state.must_equal :planned
+
+            delayed_plan.execution_plan.set_state(:running, true)
+            abstract_delayed_executor.send(:process, [delayed_plan], @start_at)
+            delayed_plan.execution_plan.state.must_equal :running
+          end
+        end
+
         it 'returns the progress as 0' do
           execution_plan.progress.must_equal 0
         end


### PR DESCRIPTION
When a process is terminated while the delayed executor is processing,
it can lead to the situation, where the plan is in weird state (such as
:planning, or :stopped), while the delayed record is still present.

This patch fixes this by returning the `:planning` state back to
`:scheduled`, and in case of other states, just skipping that, because
in that case, other resiliency mechanisms would already handled that, so
we need just to make sure we delete the delayed record at the end.