### PR TITLE
Refs #21358 - run on_failure hook on cancelled and warning states

### DIFF
--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -120,7 +120,7 @@ module Dynflow
         @ended_at       = Time.now
         @real_time      = @ended_at - @started_at unless @started_at.nil?
         @execution_time = compute_execution_time
-        hooks_to_run << (error? ? :failure : :success)
+        hooks_to_run << (failure? ? :failure : :success)
         unlock_all_singleton_locks!
       when :paused
         unlock_all_singleton_locks!
@@ -163,6 +163,10 @@ module Dynflow
 
     def error?
       result == :error
+    end
+
+    def failure?
+      [:error, :warning, :cancelled].include?(result)
     end
 
     def error_in_plan?


### PR DESCRIPTION
The cancelled state on steps introduced in a023b2907 caused the
regression, where `on_failure` hooks were not run on `cancelling`.

I've also noticed we don't run them on `warning` as well. After the
change, we do run it in both cases.