### PR TITLE
Allow middlewares to be executed around hooks

### DIFF
--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -142,7 +142,9 @@ module Dynflow
       action_ids = records.compact.map { |record| record[:id] }
       return if action_ids.empty?
       persistence.load_actions(self, action_ids).each do |action|
-        action.class.execution_plan_hooks.run(self, action, state)
+        world.middleware.execute(:hook, action, self) do
+          action.class.execution_plan_hooks.run(self, action, state)
+        end
       end
     end
 

--- a/lib/dynflow/middleware.rb
+++ b/lib/dynflow/middleware.rb
@@ -50,5 +50,9 @@ module Dynflow
     def present
       pass
     end
+
+    def hook(*args)
+      pass(*args)
+    end
   end
 end

--- a/lib/dynflow/middleware/stack.rb
+++ b/lib/dynflow/middleware/stack.rb
@@ -14,7 +14,7 @@ module Dynflow
       @middleware_class = Child! middleware_class, Middleware
       @middleware       = middleware_class.new self
       @action           = Type! action, Dynflow::Action, NilClass
-      @method           = Match! method, :delay, :plan, :run, :finalize, :plan_phase, :finalize_phase, :present
+      @method           = Match! method, :delay, :plan, :run, :finalize, :plan_phase, :finalize_phase, :present, :hook
       @next_stack       = Type! next_stack, Middleware::Stack, Proc
     end
 

--- a/lib/dynflow/middleware/world.rb
+++ b/lib/dynflow/middleware/world.rb
@@ -14,7 +14,7 @@ module Dynflow
     end
 
     def execute(method, action_or_class, *args, &block)
-      Match! method, :delay, :plan, :run, :finalize, :plan_phase, :finalize_phase, :present
+      Match! method, :delay, :plan, :run, :finalize, :plan_phase, :finalize_phase, :present, :hook
       if Child? action_or_class, Dynflow::Action
         action = nil
         action_class = action_or_class


### PR DESCRIPTION
Rationale:
When we moved repetition triggering for recurring actions into a hook, suddenly it wasn't being executed as the original user and in the original taxonomies. This will allow us to fix it once by allowing the middlewares to restore user and taxonomies before running the hook instead of having to deal with the same issue for every recurring action separately. 