### PR TITLE
Set job.provider_job_id

### DIFF
--- a/lib/dynflow/active_job/queue_adapter.rb
+++ b/lib/dynflow/active_job/queue_adapter.rb
@@ -3,11 +3,15 @@ module Dynflow
     module QueueAdapters
       module QueueMethods
         def enqueue(job)
-          ::Rails.application.dynflow.world.trigger(JobWrapper, job.serialize)
+          ::Rails.application.dynflow.world.trigger(JobWrapper, job.serialize).tap do |plan|
+            job.provider_job_id = plan.id
+          end
         end
 
         def enqueue_at(job, timestamp)
-          ::Rails.application.dynflow.world.delay(JobWrapper, { :start_at => Time.at(timestamp) }, job.serialize)
+          ::Rails.application.dynflow.world.delay(JobWrapper, { :start_at => Time.at(timestamp) }, job.serialize).tap do |plan|
+            job.provider_job_id = plan.id
+          end
         end
       end
 

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -20,7 +20,7 @@
 <% @plans.each do |plan| %>
   <tr>
     <td><%= h(plan.id) %></td>
-    <td><%= h(plan.label || plan.root_plan_step.action_class.name) %></td>
+    <td><%= h(plan.label || (plan.root_plan_step && plan.root_plan_step.action_class.name)) %></td>
     <th><%= h(plan.state) %></th>
     <th><%= h(plan.result) %></th>
     <th><%= h(plan.started_at) %></th>


### PR DESCRIPTION
This makes it easier to get to the execution plan from the job object.

During testing, I've hit a corner case, where plan.root_plan_step was nil: it's
better to be safe then sorry here.