### PR TITLE
Fixes #24119 - ensure delayed executor is preserved after invalidation

### DIFF
--- a/lib/dynflow/config.rb
+++ b/lib/dynflow/config.rb
@@ -126,7 +126,7 @@ module Dynflow
     end
 
     config_attr :validity_check_timeout, Numeric do
-      5
+      30
     end
 
     config_attr :exit_on_terminate, Algebrick::Types::Boolean do

--- a/lib/dynflow/delayed_executors/abstract.rb
+++ b/lib/dynflow/delayed_executors/abstract.rb
@@ -7,11 +7,18 @@ module Dynflow
       def initialize(world, options = {})
         @world = world
         @options = options
+        @started = false
         spawn
       end
 
+      def started?
+        @started
+      end
+
       def start
-        @core.ask(:start)
+        @core.ask(:start).tap do
+          @started = true
+        end
       end
 
       def terminate

--- a/lib/dynflow/dispatcher.rb
+++ b/lib/dynflow/dispatcher.rb
@@ -12,7 +12,8 @@ module Dynflow
       end
 
       Ping = type do
-        fields! receiver_id: String
+        fields! receiver_id: String,
+                use_cache: type { variants TrueClass, FalseClass }
       end
 
       Status = type do

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -138,7 +138,7 @@ module Dynflow
                             (on ~Event do |event|
                                find_executor(event.execution_plan_id)
                              end),
-                            (on Ping.(~any) | Status.(~any, ~any) do |receiver_id, _|
+                            (on Ping.(~any, ~any) | Status.(~any, ~any) do |receiver_id, _|
                                receiver_id
                              end)
         envelope = Envelope[request_id, client_world_id, executor_id, request]
@@ -243,6 +243,7 @@ module Dynflow
       # @return [Concurrent::Future] the future tracking the request
       def with_ping_request_caching(request, future)
         return yield unless request.is_a?(Dynflow::Dispatcher::Ping)
+        return yield unless request.use_cache
 
         if @ping_cache.fresh_record?(request.receiver_id)
           future.success(true)

--- a/lib/dynflow/executors/parallel/core.rb
+++ b/lib/dynflow/executors/parallel/core.rb
@@ -84,6 +84,12 @@ module Dynflow
           @logger.debug('Executor heartbeat')
           record = @world.coordinator.find_records(:id => @world.id,
                                                    :class => ['Dynflow::Coordinator::ExecutorWorld', 'Dynflow::Coordinator::ClientWorld']).first
+          unless record
+            logger.error(%{Executor's world record for #{@world.id} missing: terminating})
+            @world.terminate
+            return
+          end
+
           record.data[:meta].update(:last_seen => Dynflow::Dispatcher::ClientDispatcher::PingCache.format_time)
           @world.coordinator.update_record(record)
           schedule_heartbeat

--- a/lib/dynflow/rails.rb
+++ b/lib/dynflow/rails.rb
@@ -42,8 +42,9 @@ module Dynflow
           config.run_on_init_hooks(world)
           # leave this just for long-running executors
           unless config.rake_task_with_executor?
-            world.perform_validity_checks
+            invalidated_worlds = world.perform_validity_checks
             world.auto_execute
+            world.post_initialization if invalidated_worlds > 0
           end
         end
       end

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -44,6 +44,7 @@ module Dynflow
         @executor_dispatcher = spawn_and_wait(Dispatcher::ExecutorDispatcher, "executor-dispatcher", self, @config.executor_semaphore)
         executor.initialized.wait
       end
+      update_register
       perform_validity_checks if auto_validity_check
 
       @termination_barrier = Mutex.new

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -46,14 +46,6 @@ module Dynflow
       end
       perform_validity_checks if auto_validity_check
 
-      @delayed_executor         = try_spawn(:delayed_executor, Coordinator::DelayedExecutorLock)
-      @execution_plan_cleaner   = try_spawn(:execution_plan_cleaner, Coordinator::ExecutionPlanCleanerLock)
-      @meta                     = @config.meta
-      @meta['queues']           = @config.queues if @executor
-      @meta['delayed_executor'] = true if @delayed_executor
-      @meta['execution_plan_cleaner'] = true if @execution_plan_cleaner
-      @meta['last_seen'] = Dynflow::Dispatcher::ClientDispatcher::PingCache.format_time
-      coordinator.register_world(registered_world)
       @termination_barrier = Mutex.new
       @before_termination_hooks = Queue.new
 
@@ -63,12 +55,36 @@ module Dynflow
           self.terminate.wait
         end
       end
+      post_initialization
+    end
+
+    # performs steps once the executor is ready and invalidation of previous worls is finished.
+    # Needs to be indempotent, as it can be called several times (expecially when auto_validity_check
+    # if false, as it should be called after `perform_validity_checks` method)
+    def post_initialization
+      @delayed_executor ||= try_spawn(:delayed_executor, Coordinator::DelayedExecutorLock)
+      @execution_plan_cleaner ||= try_spawn(:execution_plan_cleaner, Coordinator::ExecutionPlanCleanerLock)
+      update_register
+      @delayed_executor.start if @delayed_executor && !@delayed_executor.started?
       self.auto_execute if @config.auto_execute
-      @delayed_executor.start if @delayed_executor
     end
 
     def before_termination(&block)
       @before_termination_hooks << block
+    end
+
+    def update_register
+      @meta                     ||= @config.meta
+      @meta['queues']           = @config.queues if @executor
+      @meta['delayed_executor'] = true if @delayed_executor
+      @meta['execution_plan_cleaner'] = true if @execution_plan_cleaner
+      @meta['last_seen'] = Dynflow::Dispatcher::ClientDispatcher::PingCache.format_time
+      if @already_registered
+        coordinator.update_record(registered_world)
+      else
+        coordinator.register_world(registered_world)
+        @already_registered = true
+      end
     end
 
     def registered_world
@@ -197,7 +213,11 @@ module Dynflow
     end
 
     def ping(world_id, timeout, done = Concurrent.future)
-      publish_request(Dispatcher::Ping[world_id], done, false, timeout)
+      publish_request(Dispatcher::Ping[world_id, true], done, false, timeout)
+    end
+
+    def ping_without_cache(world_id, timeout, done = Concurrent.future)
+      publish_request(Dispatcher::Ping[world_id, false], done, false, timeout)
     end
 
     def get_execution_status(world_id, execution_plan_id, timeout, done = Concurrent.future)
@@ -274,6 +294,7 @@ module Dynflow
       defined?(@terminating)
     end
 
+    # 24119 - ensure delayed executor is preserved after invalidation
     # executes plans that are planned/paused and haven't reported any error yet (usually when no executor
     # was available by the time of planning or terminating)
     def auto_execute

--- a/lib/dynflow/world/invalidation.rb
+++ b/lib/dynflow/world/invalidation.rb
@@ -96,10 +96,11 @@ module Dynflow
 
       # Performs world validity checks
       #
-      # @return [void]
+      # @return [Integer] number of invalidated worlds
       def perform_validity_checks
-        worlds_validity_check
+        world_invalidation_result = worlds_validity_check
         locks_validity_check
+        world_invalidation_result.values.select { |result| result == :invalidated }.size
       end
 
       # Checks if all worlds are valid and optionally invalidates them
@@ -111,7 +112,7 @@ module Dynflow
         worlds = coordinator.find_worlds(false, worlds_filter)
 
         world_checks = worlds.reduce({}) do |hash, world|
-          hash.update(world => ping(world.id, self.validity_check_timeout))
+          hash.update(world => ping_without_cache(world.id, self.validity_check_timeout))
         end
         world_checks.values.each(&:wait)
 

--- a/test/daemon_test.rb
+++ b/test/daemon_test.rb
@@ -17,7 +17,7 @@ class DaemonTest < ActiveSupport::TestCase
     @dummy_world = ::Dynflow::Testing::DummyWorld.new
     @dummy_world.stubs(:id => '123')
     @dummy_world.stubs(:auto_execute)
-    @dummy_world.stubs(:perform_validity_checks)
+    @dummy_world.stubs(:perform_validity_checks => 0)
     @event = Concurrent.event
     @dummy_world.stubs(:terminated).returns(@event)
     @world_class.stubs(:new).returns(@dummy_world)
@@ -42,7 +42,14 @@ class DaemonTest < ActiveSupport::TestCase
     @event.wait
   end
 
-  test 'run command works withou memory_limit option specified' do
+  test 'run command works without memory_limit option specified' do
+    @daemon.run(@current_folder)
+    @dynflow.initialize!
+  end
+
+  test 'runs post_initialization when there are invalid worlds detected' do
+    @dummy_world.stubs(:perform_validity_checks => 1)
+    @dummy_world.expects(:post_initialization)
     @daemon.run(@current_folder)
     @dynflow.initialize!
   end

--- a/test/dispatcher_test.rb
+++ b/test/dispatcher_test.rb
@@ -76,9 +76,22 @@ module Dynflow
             assert ping_response.success?
           end
 
+          it 'succeeds when the world is available without cache' do
+            ping_response = client_world.ping_without_cache(executor_world.id, 0.5)
+            ping_response.wait
+            assert ping_response.success?
+          end
+
           it 'time-outs when the world is not responding' do
             executor_world.terminate.wait
             ping_response = client_world.ping(executor_world.id, 0.5)
+            ping_response.wait
+            assert ping_response.failed?
+          end
+
+          it 'time-outs when the world is not responding without cache' do
+            executor_world.terminate.wait
+            ping_response = client_world.ping_without_cache(executor_world.id, 0.5)
             ping_response.wait
             assert ping_response.failed?
           end


### PR DESCRIPTION
We do two things to achieve this:

  1. re-initialize the delayed executor if some worlds were invalidated

  2. don't use ping cache at executors startup - this way we handle the
  case, when the executor gets force killed and the timeout doesn't
  expire before the new executor goes up. I've increased the ping
  timeout to avoid false negatives

Steps to reproduce:

1. run executor with rails environment (with foreman-tasks)
2. force kill the executor
3. run executor again

Without this patch: the old executor doesn't get invalidated at startup and even it it gets (when waiting for a minute between step 2 and 3, it doesn't get the delayed executor started.