### PR TITLE
Handle situation when execution plan gets deleted

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,7 @@ Style/MultilineOperationIndentation:
 # Cop supports --auto-correct.
 Style/EmptyLines:
   Enabled: true
+
+Metrics/ModuleLength:
+  Exclude:
+  - test/**/*

--- a/lib/dynflow/coordinator_adapters/sequel.rb
+++ b/lib/dynflow/coordinator_adapters/sequel.rb
@@ -9,8 +9,12 @@ module Dynflow
 
       def create_record(record)
         @sequel_adapter.insert_coordinator_record(record.to_hash)
-      rescue ::Sequel::UniqueConstraintViolation
-        raise Coordinator::DuplicateRecordError.new(record)
+      rescue Errors::PersistenceError => e
+        if e.cause.is_a? ::Sequel::UniqueConstraintViolation
+          raise Coordinator::DuplicateRecordError.new(record)
+        else
+          raise e
+        end
       end
 
       def update_record(record)

--- a/lib/dynflow/errors.rb
+++ b/lib/dynflow/errors.rb
@@ -34,12 +34,17 @@ module Dynflow
     class DataConsistencyError < Dynflow::Error
     end
 
+    # any persistence errors
     class PersistenceError < Dynflow::Error
       def self.delegate(original_exception)
         self.new("caused by #{original_exception.class}: #{original_exception.message}").tap do |e|
           e.set_backtrace original_exception.backtrace
         end
       end
+    end
+
+    # persistence errors that can't be recovered from, such as continuous connection issues
+    class FatalPersistenceError < PersistenceError
     end
   end
 end

--- a/lib/dynflow/executors/parallel/pool.rb
+++ b/lib/dynflow/executors/parallel/pool.rb
@@ -65,8 +65,10 @@ module Dynflow
           distribute_jobs
         end
 
-        def handle_persistence_error(error)
-          @executor_core.tell([:handle_persistence_error, error])
+        def handle_persistence_error(worker, error, work = nil)
+          @executor_core.tell([:handle_persistence_error, error, work])
+          @free_workers << worker
+          distribute_jobs
         end
 
         def start_termination(*args)

--- a/lib/dynflow/executors/parallel/worker.rb
+++ b/lib/dynflow/executors/parallel/worker.rb
@@ -8,13 +8,15 @@ module Dynflow
         end
 
         def on_message(work_item)
+          already_responded = false
           Executors.run_user_code do
             work_item.execute
           end
         rescue Errors::PersistenceError => e
-          @pool.tell([:handle_persistence_error, e])
+          @pool.tell([:handle_persistence_error, reference, e, work_item])
+          already_responded = true
         ensure
-          @pool.tell([:worker_done, reference, work_item])
+          @pool.tell([:worker_done, reference, work_item]) unless already_responded
         end
       end
     end

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -435,19 +435,19 @@ module Dynflow
         attempts = 0
         begin
           yield
-        rescue ::Sequel::UniqueConstraintViolation => e
-          raise e
-        rescue Exception => e
+        rescue ::Sequel::DatabaseConnectionError, ::Sequel::DatabaseDisconnectError => e
           attempts += 1
           log(:error, e)
           if attempts > MAX_RETRIES
             log(:error, "The number of MAX_RETRIES exceeded")
-            raise Errors::PersistenceError.delegate(e)
+            raise Errors::FatalPersistenceError.delegate(e)
           else
             log(:error, "Persistence retry no. #{attempts}")
             sleep RETRY_DELAY
             retry
           end
+        rescue Exception => e
+          raise Errors::PersistenceError.delegate(e)
         end
       end
 

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -94,6 +94,7 @@ module Dynflow
         end
 
         describe "when being executed" do
+          include TestHelpers
 
           let :execution_plan do
             world.plan(Support::CodeWorkflowExample::IncomingIssue, { 'text' => 'get a break' })
@@ -126,6 +127,16 @@ module Dynflow
           it "fails when trying to execute again" do
             TestPause.when_paused do
               assert_raises(Dynflow::Error) { world.execute(execution_plan.id).value! }
+            end
+          end
+
+          it "handles when the execution plan is deleted" do
+            TestPause.when_paused do
+              world.persistence.delete_execution_plans(uuid: [execution_plan.id])
+            end
+            director = get_director(world)
+            wait_for('execution plan removed from executor') do
+              !director.current_execution_plan_ids.include?(execution_plan.id)
             end
           end
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -162,15 +162,21 @@ module TestHelpers
     end
   end
 
+  # get director for deeper investigation of the current execution state
+  def get_director(world)
+    core_context = world.executor.instance_variable_get('@core').instance_variable_get('@core').context
+    core_context.instance_variable_get('@director')
+  end
+
   # waits for the passed block to return non-nil value and reiterates it while getting false
   # (till some reasonable timeout). Useful for forcing the tests for some event to occur
-  def wait_for
+  def wait_for(waiting_message = 'something to happen')
     30.times do
       ret = yield
       return ret if ret
       sleep 0.3
     end
-    raise 'waiting for something to happen was not successful'
+    raise "waiting for #{waiting_message} was not successful"
   end
 
   def executor_id_for_plan(execution_plan_id)


### PR DESCRIPTION
Before this patch, we were considering every persistence issue as
something that we could retry on and the only resolution if that was not
successful, was executor termination.

With this patch, we keep the retry mechanism just for connection issues
and for other persistence issues, we just clean up the runtime.