### PR TITLE
Fixes #24435 - Remove round robin from the job storage

### DIFF
--- a/lib/dynflow/web/console.rb
+++ b/lib/dynflow/web/console.rb
@@ -41,9 +41,6 @@ module Dynflow
         load_worlds
         @executors.each do |w|
           hash = world.get_execution_status(w.data['id'], nil, 5).value!
-          hash.each do |_queue_name, info|
-            info[:queue_size] = info[:execution_status].values.reduce(:+) || 0
-          end
           w.data.update(:status => hash)
         end
         erb :worlds

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -594,12 +594,12 @@ module Dynflow
         let(:storage) { Dynflow::Executors::Parallel::Pool::JobStorage.new }
         it do
           storage.must_be_empty
-          storage.execution_status.must_equal({})
+          storage.queue_size.must_equal(0)
           storage.pop.must_be_nil
           storage.pop.must_be_nil
 
           storage.add s = FakeStep.new(1)
-          storage.execution_status.must_equal(1 => 1)
+          storage.queue_size.must_equal(1)
           storage.pop.must_equal s
           storage.must_be_empty
           storage.pop.must_be_nil
@@ -611,19 +611,19 @@ module Dynflow
           storage.add s22 = FakeStep.new(2)
           storage.add s31 = FakeStep.new(3)
 
-          storage.execution_status(1).must_equal(1 => 3)
-          storage.execution_status(4).must_equal(4 => 0)
-          storage.execution_status.must_equal({1 => 3, 2 => 2, 3 => 1})
+          storage.queue_size(1).must_equal(3)
+          storage.queue_size(4).must_equal(0)
+          storage.queue_size.must_equal(6)
 
-          storage.pop.must_equal s21
-          storage.pop.must_equal s31
           storage.pop.must_equal s11
-          storage.pop.must_equal s22
           storage.pop.must_equal s12
           storage.pop.must_equal s13
+          storage.pop.must_equal s21
+          storage.pop.must_equal s22
+          storage.pop.must_equal s31
 
           storage.must_be_empty
-          storage.execution_status.must_equal({})
+          storage.queue_size.must_equal(0)
           storage.pop.must_be_nil
         end
       end

--- a/test/world_test.rb
+++ b/test/world_test.rb
@@ -24,16 +24,16 @@ module Dynflow
 
       describe '#get_execution_status' do
         let(:base) do
-          { :default => { :pool_size => 5, :free_workers => 5, :execution_status => {} },
-            :slow => { :pool_size=> 1, :free_workers=> 1, :execution_status=> {}} }
+          { :default => { :pool_size => 5, :free_workers => 5, :queue_size => 0 },
+            :slow => { :pool_size=> 1, :free_workers=> 1, :queue_size => 0} }
         end
 
         it 'retrieves correct execution items count' do
           world.get_execution_status(world.id, nil, 5).value!.must_equal(base)
           id = 'something like uuid'
           expected = base.dup
-          expected[:default][:execution_status] = { id => 0 }
-          expected[:slow][:execution_status] = { id => 0 }
+          expected[:default][:queue_size] = 0
+          expected[:slow][:queue_size] =  0
           world.get_execution_status(world.id, id, 5).value!.must_equal(expected)
         end
       end


### PR DESCRIPTION
This was leading to some unexpected behavior: using simple FIFO instead.

This PR aslo adds simple benchmarking script to compare the behavior: ideal in
combination with the telemetry.