### PR TITLE
Fixes #24761 - skip rescue strategy for active job

### DIFF
--- a/lib/dynflow/active_job/queue_adapter.rb
+++ b/lib/dynflow/active_job/queue_adapter.rb
@@ -45,6 +45,10 @@ module Dynflow
         def label
           input[:job_class]
         end
+
+        def rescue_strategy
+          Action::Rescue::Skip
+        end
       end
     end
   end


### PR DESCRIPTION
There is no point in pausing active job, as they never consist from more
than one step.