### PR TITLE
Fixes #25021 - add more termination timeouts

### DIFF
--- a/lib/dynflow/connectors/abstract.rb
+++ b/lib/dynflow/connectors/abstract.rb
@@ -8,7 +8,11 @@ module Dynflow
         raise NotImplementedError
       end
 
-      def stop_listening(world)
+      def stop_receiving_new_work(_, timeout = nil)
+        raise NotImplementedError
+      end
+
+      def stop_listening(world, timeout = nil)
         raise NotImplementedError
       end
 

--- a/lib/dynflow/connectors/database.rb
+++ b/lib/dynflow/connectors/database.rb
@@ -159,12 +159,12 @@ module Dynflow
         @core.ask([:start_listening, world])
       end
 
-      def stop_receiving_new_work(_)
-        @core.ask(:stop_receiving_new_work).wait
+      def stop_receiving_new_work(_, timeout = nil)
+        @core.ask(:stop_receiving_new_work).wait(timeout)
       end
 
-      def stop_listening(_)
-        @core.ask(:stop_listening).then { @core.ask(:terminate!) }.wait
+      def stop_listening(_, timeout = nil)
+        @core.ask(:stop_listening).then { @core.ask(:terminate!) }.wait(timeout)
       end
 
       def send(envelope)

--- a/lib/dynflow/connectors/direct.rb
+++ b/lib/dynflow/connectors/direct.rb
@@ -55,12 +55,12 @@ module Dynflow
         @core.ask([:start_listening, world])
       end
 
-      def stop_receiving_new_work(world)
-        @core.ask([:stop_receiving_new_work, world]).wait
+      def stop_receiving_new_work(world, timeout = nil)
+        @core.ask([:stop_receiving_new_work, world]).wait(timeout)
       end
 
-      def stop_listening(world)
-        @core.ask([:stop_listening, world]).wait
+      def stop_listening(world, timeout = nil)
+        @core.ask([:stop_listening, world]).wait(timeout)
       end
 
       def send(envelope)

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -243,7 +243,48 @@ module Dynflow
     end
 
     def terminate(future = Concurrent.future)
+      start_termination.tangle(future)
+      future
+    end
+
+    def terminating?
+      defined?(@terminating)
+    end
+
+    # 24119 - ensure delayed executor is preserved after invalidation
+    # executes plans that are planned/paused and haven't reported any error yet (usually when no executor
+    # was available by the time of planning or terminating)
+    def auto_execute
+      coordinator.acquire(Coordinator::AutoExecuteLock.new(self)) do
+        planned_execution_plans =
+            self.persistence.find_execution_plans filters: { 'state' => %w(planned paused), 'result' => (ExecutionPlan.results - [:error]).map(&:to_s) }
+        planned_execution_plans.map do |ep|
+          if coordinator.find_locks(Dynflow::Coordinator::ExecutionLock.unique_filter(ep.id)).empty?
+            execute(ep.id)
+          end
+        end.compact
+      end
+    rescue Coordinator::LockError => e
+      logger.info "auto-executor lock already aquired: #{e.message}"
+      []
+    end
+
+    def try_spawn(what, lock_class = nil)
+      object = nil
+      return nil if !executor || (object = @config.public_send(what)).nil?
+
+      coordinator.acquire(lock_class.new(self)) if lock_class
+      object.spawn.wait
+      object
+    rescue Coordinator::LockError => e
+      nil
+    end
+
+    private
+
+    def start_termination
       @termination_barrier.synchronize do
+        return @terminating if @terminating
         termination_future ||= Concurrent.future do
           begin
             run_before_termination_hooks
@@ -294,45 +335,8 @@ module Dynflow
           Thread.new { Kernel.exit } if @exit_on_terminate.true?
         end
       end
-
-      @terminating.tangle(future)
-      future
     end
 
-    def terminating?
-      defined?(@terminating)
-    end
-
-    # 24119 - ensure delayed executor is preserved after invalidation
-    # executes plans that are planned/paused and haven't reported any error yet (usually when no executor
-    # was available by the time of planning or terminating)
-    def auto_execute
-      coordinator.acquire(Coordinator::AutoExecuteLock.new(self)) do
-        planned_execution_plans =
-            self.persistence.find_execution_plans filters: { 'state' => %w(planned paused), 'result' => (ExecutionPlan.results - [:error]).map(&:to_s) }
-        planned_execution_plans.map do |ep|
-          if coordinator.find_locks(Dynflow::Coordinator::ExecutionLock.unique_filter(ep.id)).empty?
-            execute(ep.id)
-          end
-        end.compact
-      end
-    rescue Coordinator::LockError => e
-      logger.info "auto-executor lock already aquired: #{e.message}"
-      []
-    end
-
-    def try_spawn(what, lock_class = nil)
-      object = nil
-      return nil if !executor || (object = @config.public_send(what)).nil?
-
-      coordinator.acquire(lock_class.new(self)) if lock_class
-      object.spawn.wait
-      object
-    rescue Coordinator::LockError => e
-      nil
-    end
-
-    private
     def calculate_subscription_index
       @subscription_index =
           action_classes.each_with_object(Hash.new { |h, k| h[k] = [] }) do |klass, index|


### PR DESCRIPTION
This patch adds a timeout for some connector events, waiting for
termination hooks, as well as a global termination timeout to make sure we
don't get stuck forever.

I've added the extraction of the method to separate commit, so that it's easier
to see the changes in the orinial method.