### PR TITLE
Ensure we don't end up with plans stuck in planning

### DIFF
--- a/lib/dynflow/coordinator.rb
+++ b/lib/dynflow/coordinator.rb
@@ -294,6 +294,22 @@ module Dynflow
       end
     end
 
+    class PlanningLock < LockByWorld
+      def initialize(world, execution_plan_id)
+        super(world)
+        @data.merge!(id: self.class.lock_id(execution_plan_id),
+                     execution_plan_id: execution_plan_id)
+      end
+
+      def self.lock_id(execution_plan_id)
+        'execution-plan:' + execution_plan_id
+      end
+
+      def execution_plan_id
+        @data[:execution_plan_id]
+      end
+    end
+
     attr_reader :adapter
 
     def initialize(coordinator_adapter)

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -200,8 +200,10 @@ module Dynflow
 
     def plan_with_options(action_class:, args:, id: nil, caller_action: nil)
       ExecutionPlan.new(self, id).tap do |execution_plan|
-        execution_plan.prepare(action_class, caller_action: caller_action)
-        execution_plan.plan(*args)
+        coordinator.acquire(Coordinator::PlanningLock.new(self, execution_plan.id)) do
+          execution_plan.prepare(action_class, caller_action: caller_action)
+          execution_plan.plan(*args)
+        end
       end
     end
 

--- a/lib/dynflow/world/invalidation.rb
+++ b/lib/dynflow/world/invalidation.rb
@@ -35,7 +35,7 @@ module Dynflow
         with_valid_execution_plan_for_lock(planning_lock) do |plan|
           plan.steps.values.each { |step| invalidate_step step }
 
-          state = plan.steps.values.all? { |step| step.state == :success } ? :planned : :stopped
+          state = plan.plan_steps.all? { |step| step.state == :success } ? :planned : :stopped
           plan.update_state(state)
           coordinator.release(planning_lock)
           execute(plan.id) if plan.state == :planned

--- a/lib/dynflow/world/invalidation.rb
+++ b/lib/dynflow/world/invalidation.rb
@@ -35,9 +35,10 @@ module Dynflow
         with_valid_execution_plan_for_lock(planning_lock) do |plan|
           plan.steps.values.each { |step| invalidate_step step }
 
-          plan.update_state(:stopped)
-          plan.save
+          state = plan.steps.values.all? { |step| step.state == :success } ? :planned : :stopped
+          plan.update_state(state)
           coordinator.release(planning_lock)
+          execute(plan.id) if plan.state == :planned
         end
       end
 

--- a/lib/dynflow/world/invalidation.rb
+++ b/lib/dynflow/world/invalidation.rb
@@ -11,6 +11,11 @@ module Dynflow
         Type! world, Coordinator::ClientWorld, Coordinator::ExecutorWorld
 
         coordinator.acquire(Coordinator::WorldInvalidationLock.new(self, world)) do
+          coordinator.find_locks(class: Coordinator::PlanningLock.name,
+                                 owner_id: 'world:' + world.id).each do |lock|
+            invalidate_planning_lock lock
+          end
+
           if world.is_a? Coordinator::ExecutorWorld
             old_execution_locks = coordinator.find_locks(class: Coordinator::ExecutionLock.name,
                                                          owner_id: "world:#{world.id}")
@@ -26,6 +31,16 @@ module Dynflow
         end
       end
 
+      def invalidate_planning_lock(planning_lock)
+        with_valid_execution_plan_for_lock(planning_lock) do |plan|
+          plan.steps.values.each { |step| invalidate_step step }
+
+          plan.update_state(:stopped)
+          plan.save
+          coordinator.release(planning_lock)
+        end
+      end
+
       # Invalidate an execution lock, left behind by a executor that
       # was executing an execution plan when it was terminated.
       #
@@ -33,14 +48,7 @@ module Dynflow
       # @return [void]
       def invalidate_execution_lock(execution_lock)
         with_valid_execution_plan_for_lock(execution_lock) do |plan|
-          plan.steps.values.each do |step|
-            if step.state == :running
-              step.error = ExecutionPlan::Steps::Error.new("Abnormal termination (previous state: #{step.state})")
-              step.state = :error
-              step.save
-            end
-          end
-
+          plan.steps.values.each { |step| invalidate_step step }
           plan.execution_history.add('terminate execution', execution_lock.world_id)
           plan.update_state(:paused, history_notice: false) if plan.state == :running
           plan.save
@@ -154,6 +162,16 @@ module Dynflow
         end
 
         return orphaned_locks
+      end
+
+      private
+
+      def invalidate_step(step)
+        if step.state == :running
+          step.error = ExecutionPlan::Steps::Error.new("Abnormal termination (previous state: #{step.state})")
+          step.state = :error
+          step.save
+        end
       end
     end
   end

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require_relative 'test_helper'
+require 'mocha/minitest'
 
 module Dynflow
   module ExecutorTest
@@ -669,6 +670,7 @@ module Dynflow
 
       it 'does not accept new work' do
         assert world.terminate.wait
+        ::Dynflow::Coordinator::PlanningLock.any_instance.stubs(:validate!)
         result = world.trigger(Support::DummyExample::Slow, 0.02)
         result.must_be :planned?
         result.finished.wait


### PR DESCRIPTION
If the process planning an execution plan is killed before it can finish,
there's a chance it will get stuck in this state forever. This commit introduces
planning locks so we can stop the execution plans which are not really being
planned anymore during invalidation.