### PR TITLE
Make sure an execution plan cannot be its own sub plan

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -161,11 +161,11 @@ module Dynflow
     end
 
     def caller_action
-      plase! Present
+      phase! Present
       return nil if @caller_action_id
       return @caller_action if @caller_action
 
-      caller_execution_plan = if @caller_execution_plan_id == execution_plan.id
+      caller_execution_plan = if @caller_execution_plan_id.nil?
                                 execution_plan
                               else
                                 world.persistence.load_execution_plan(@caller_execution_plan_id)

--- a/lib/dynflow/execution_plan/steps/plan_step.rb
+++ b/lib/dynflow/execution_plan/steps/plan_step.rb
@@ -98,8 +98,10 @@ module Dynflow
                        finalize_step_id:  nil,
                        phase:             phase }
         if caller_action
-          attributes.update(caller_execution_plan_id: caller_action.execution_plan_id,
-                            caller_action_id:         caller_action.id)
+          if caller_action.execution_plan_id != execution_plan_id
+            attributes.update(caller_execution_plan_id: caller_action.execution_plan_id)
+          end
+          attributes.update(caller_action_id: caller_action.id)
         end
         @action = action_class.new(attributes, world)
         persistence.save_action(execution_plan_id, @action)

--- a/test/execution_plan_test.rb
+++ b/test/execution_plan_test.rb
@@ -141,6 +141,17 @@ module Dynflow
 
       end
 
+      describe 'sub plans' do
+        let(:execution_plan) do
+          world.plan(Support::CodeWorkflowExample::IncomingIssues, issues_data)
+        end
+
+        it 'does not have itself as a sub plan' do
+          assert execution_plan.actions.count >= 2
+          execution_plan.sub_plans.must_be :empty?
+        end
+      end
+
       describe 'plan steps' do
         let :execution_plan do
           world.plan(Support::CodeWorkflowExample::IncomingIssues, issues_data)


### PR DESCRIPTION
Previously the following would hold as a definition of a sub plan:
Execution plan E2 is a sub plan of E1 if E2 has at least one action with
caller_execution_plan_id set to E1.id.

Let's consider an execution plan E1 with a single action A1. A1's
caller_{execution_plan,action}_id is nil and everything is in order.

However if we would plan action A2 from A1, A2's caller_execution_plan_id would
be set to E1.id and caller_action_id to A1.id. According to the previous
definition E1 would be considered a sub plan of itself.

With this patch only execution plan's entry action can have
caller_execution_plan_id set. This way, we shouldn't reach a situation where an
execution plan is its own sub plan.