### PR TITLE
Fix travis on ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ sudo: false
 language:
   - ruby
 
+before_install: >-
+  if ruby -v | grep 'ruby 2.2'; then
+    gem install bundler -v '~> 1.17'
+  fi
+
 rvm:
   - "2.2.2"
   - "2.3.1"


### PR DESCRIPTION
This fixes the following issue:

```
 The program 'bundle' is currently not installed. To run
'bundle' please ask your administrator to install the package 'bundler'.

```

Seems like the issue is the bundler 2.0 is not compatible with
ruby < 2.3.0