### PR TITLE
Make the job_provider_id available in the worker

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  TargetRubyVersion: 2.2
+
 # Cop supports --auto-correct.
 # Configuration parameters: AllowForAlignment, ForceEqualSignAlignment.
 Style/ExtraSpacing:

--- a/lib/dynflow/action/with_sub_plans.rb
+++ b/lib/dynflow/action/with_sub_plans.rb
@@ -76,16 +76,16 @@ module Dynflow
     end
 
     # Helper for creating sub plans
-    def trigger(*args)
+    def trigger(action_class, *args)
       if uses_concurrency_control
-        trigger_with_concurrency_control(*args)
+        trigger_with_concurrency_control(action_class, *args)
       else
-        world.trigger { world.plan_with_caller(self, *args) }
+        world.trigger { world.plan_with_options(action_class: action_class, args: args, caller_action: self) }
       end
     end
 
-    def trigger_with_concurrency_control(*args)
-      record = world.plan_with_caller(self, *args)
+    def trigger_with_concurrency_control(action_class, *args)
+      record = world.plan_with_options(action_class: action_class, args: args, caller_action: self)
       records = [[record.id], []]
       records.reverse! unless record.state == :planned
       @world.throttle_limiter.handle_plans!(execution_plan_id, *records).first

--- a/lib/dynflow/active_job/queue_adapter.rb
+++ b/lib/dynflow/active_job/queue_adapter.rb
@@ -3,15 +3,19 @@ module Dynflow
     module QueueAdapters
       module QueueMethods
         def enqueue(job)
-          ::Rails.application.dynflow.world.trigger(JobWrapper, job.serialize).tap do |plan|
-            job.provider_job_id = plan.id
+          ::Rails.application.dynflow.world.trigger do |world|
+            job.provider_job_id = job.job_id
+            world.plan_with_options(id: job.provider_job_id, action_class: JobWrapper, args: [job.serialize])
           end
         end
 
         def enqueue_at(job, timestamp)
-          ::Rails.application.dynflow.world.delay(JobWrapper, { :start_at => Time.at(timestamp) }, job.serialize).tap do |plan|
-            job.provider_job_id = plan.id
-          end
+          job.provider_job_id = job.job_id
+          ::Rails.application.dynflow.world
+            .delay_with_options(id: job.provider_job_id,
+                                action_class: JobWrapper,
+                                delay_options: { :start_at => Time.at(timestamp) },
+                                args: [job.serialize])
         end
       end
 
@@ -33,13 +37,13 @@ module Dynflow
 
         def plan(attributes)
           input[:job_class] = attributes['job_class']
-          input[:job_arguments] = attributes['arguments']
           input[:queue] = attributes['queue_name']
+          input[:job_data] = attributes
           plan_self
         end
 
         def run
-          input[:job_class].constantize.perform_now(*input[:job_arguments])
+          ::ActiveJob::Base.execute(input[:job_data])
         end
 
         def label

--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -69,7 +69,7 @@ module Dynflow
 
     # all params with default values are part of *private* api
     def initialize(world,
-                   id                = SecureRandom.uuid,
+                   id                = nil,
                    label             = nil,
                    state             = :pending,
                    root_plan_step    = nil,
@@ -81,7 +81,7 @@ module Dynflow
                    execution_time    = nil,
                    real_time         = 0.0,
                    execution_history = ExecutionHistory.new)
-
+      id ||= SecureRandom.uuid
       @id                = Type! id, String
       @world             = Type! world, World
       @label             = Type! label, String, NilClass

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -183,26 +183,23 @@ module Dynflow
       end
     end
 
-    def delay(*args)
-      delay_with_caller(nil, *args)
+    def delay(action_class, delay_options, *args)
+      delay_with_options(action_class: action_class, args: args, delay_options: delay_options)
     end
 
-    def delay_with_caller(caller_action, action_class, delay_options, *args)
+    def delay_with_options(action_class:, args:, delay_options:, id: nil, caller_action: nil)
       raise 'No action_class given' if action_class.nil?
-      execution_plan = ExecutionPlan.new(self)
+      execution_plan = ExecutionPlan.new(self, id)
       execution_plan.delay(caller_action, action_class, delay_options, *args)
       Scheduled[execution_plan.id]
     end
 
     def plan(action_class, *args)
-      ExecutionPlan.new(self).tap do |execution_plan|
-        execution_plan.prepare(action_class)
-        execution_plan.plan(*args)
-      end
+      plan_with_options(action_class: action_class, args: args)
     end
 
-    def plan_with_caller(caller_action, action_class, *args)
-      ExecutionPlan.new(self).tap do |execution_plan|
+    def plan_with_options(action_class:, args:, id: nil, caller_action: nil)
+      ExecutionPlan.new(self, id).tap do |execution_plan|
         execution_plan.prepare(action_class, caller_action: caller_action)
         execution_plan.plan(*args)
       end

--- a/test/execution_plan_test.rb
+++ b/test/execution_plan_test.rb
@@ -191,6 +191,18 @@ module Dynflow
         end
       end
 
+      describe 'custom plan id' do
+        let :execution_plan do
+          world.plan_with_options(action_class: Support::CodeWorkflowExample::IncomingIssues,
+                                  args: [issues_data],
+                                  id: 'my-unique-id')
+        end
+
+        it 'allows setting custom id for the execution plan' do
+          execution_plan.id.must_equal 'my-unique-id'
+        end
+      end
+
       describe 'planning algorithm' do
 
         describe 'single dependencies' do

--- a/test/execution_plan_test.rb
+++ b/test/execution_plan_test.rb
@@ -192,14 +192,15 @@ module Dynflow
       end
 
       describe 'custom plan id' do
+        let(:sample_uuid) { '60366107-9910-4815-a6c6-bc45ee2ea2b8' }
         let :execution_plan do
           world.plan_with_options(action_class: Support::CodeWorkflowExample::IncomingIssues,
                                   args: [issues_data],
-                                  id: 'my-unique-id')
+                                  id: sample_uuid)
         end
 
         it 'allows setting custom id for the execution plan' do
-          execution_plan.id.must_equal 'my-unique-id'
+          execution_plan.id.must_equal sample_uuid
         end
       end
 


### PR DESCRIPTION
Also make execution_plan.id match active_job.id, which makes it easier to
use single uuid to search the data across the active job and dynflow realm.

As part of this change, we've made it possible to set the execution plan id
to custom value (the developer needs to be careful to not use duplicate keys: with great power
comes great responsiblity).