### PR TITLE
Reduce status updates on rescue

### DIFF
--- a/lib/dynflow/director.rb
+++ b/lib/dynflow/director.rb
@@ -119,9 +119,9 @@ module Dynflow
     def work_failed(work)
       if (manager = @execution_plan_managers[work.execution_plan_id])
         manager.terminate
-        # work failed means there was probably a database issue (execution plan gone missing). Don't try
-        # to store the status in that case.
-        finish_manager(manager, store: false)
+        # Don't try to store when the execution plan went missing
+        plan_missing = @world.persistence.find_execution_plans(:filters => { uuid: work.execution_plan_id }).empty?
+        finish_manager(manager, store: !plan_missing)
       end
     end
 

--- a/lib/dynflow/director.rb
+++ b/lib/dynflow/director.rb
@@ -216,8 +216,8 @@ module Dynflow
       execution_plan = manager.execution_plan
       if execution_plan.state == :running
         if execution_plan.error?
-          execution_plan.update_state(:paused)
           execution_plan.execution_history.add('pause execution', @world.id)
+          execution_plan.update_state(:paused)
         elsif manager.done?
           execution_plan.execution_history.add('finish execution', @world.id)
           execution_plan.update_state(:stopped)
@@ -225,7 +225,6 @@ module Dynflow
         # If the state is marked as running without errors but manager is not done,
         # we let the invalidation procedure to handle re-execution on other executor
       end
-      execution_plan.save
     end
 
     def set_future(manager)

--- a/lib/dynflow/director.rb
+++ b/lib/dynflow/director.rb
@@ -187,7 +187,7 @@ module Dynflow
       if new_state == :running
         return manager.restart
       else
-        manager.execution_plan.update_state(new_state)
+        manager.execution_plan.state = new_state
         return false
       end
     end
@@ -214,7 +214,8 @@ module Dynflow
 
     def update_execution_plan_state(manager)
       execution_plan = manager.execution_plan
-      if execution_plan.state == :running
+      case execution_plan.state
+      when :running
         if execution_plan.error?
           execution_plan.execution_history.add('pause execution', @world.id)
           execution_plan.update_state(:paused)
@@ -224,6 +225,12 @@ module Dynflow
         end
         # If the state is marked as running without errors but manager is not done,
         # we let the invalidation procedure to handle re-execution on other executor
+      when :paused
+        execution_plan.execution_history.add('pause execution', @world.id)
+        execution_plan.save
+      when :stopped
+        execution_plan.execution_history.add('finish execution', @world.id)
+        execution_plan.save
       end
     end
 

--- a/lib/dynflow/director/execution_plan_manager.rb
+++ b/lib/dynflow/director/execution_plan_manager.rb
@@ -24,6 +24,12 @@ module Dynflow
         start_run or start_finalize or finish
       end
 
+      def restart
+        @run_manager = nil
+        @finalize_manager = nil
+        start
+      end
+
       def prepare_next_step(step)
         StepWorkItem.new(execution_plan.id, step, step.queue).tap do |work|
           @running_steps_manager.add(step, work)
@@ -97,8 +103,6 @@ module Dynflow
       end
 
       def finish
-        execution_plan.execution_history.add('finish execution', @world.id)
-        @execution_plan.update_state(execution_plan.error? ? :paused : :stopped)
         return no_work
       end
 

--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -202,14 +202,14 @@ module Dynflow
     def prepare_for_rescue
       case rescue_strategy
       when Action::Rescue::Pause
-        return :paused
+        :paused
       when Action::Rescue::Fail
-        return :stopped
+        :stopped
       when Action::Rescue::Skip
         failed_steps.each { |step| self.skip(step) }
-        return :running
+        :running
       else
-        return :paused
+        :paused
       end
     end
 

--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -199,16 +199,17 @@ module Dynflow
       persistence.find_execution_plan_counts(filters: { 'caller_execution_plan_id' => self.id })
     end
 
-    def rescue_plan_id
+    def prepare_for_rescue
       case rescue_strategy
       when Action::Rescue::Pause
-        nil
+        return :paused
       when Action::Rescue::Fail
-        update_state :stopped
-        nil
+        return :stopped
       when Action::Rescue::Skip
         failed_steps.each { |step| self.skip(step) }
-        self.id
+        return :running
+      else
+        return :paused
       end
     end
 
@@ -230,14 +231,6 @@ module Dynflow
 
     def steps_in_state(*states)
       self.steps.values.find_all {|step| states.include?(step.state) }
-    end
-
-    def rescue_from_error
-      if rescue_plan_id = self.rescue_plan_id
-        @world.execute(rescue_plan_id)
-      else
-        raise Errors::RescueError, 'Unable to rescue from the error'
-      end
     end
 
     def generate_action_id

--- a/test/abnormal_states_recovery_test.rb
+++ b/test/abnormal_states_recovery_test.rb
@@ -198,7 +198,7 @@ module Dynflow
           plan = client_world.persistence.load_execution_plan(triggered.id)
           plan.state.must_equal :paused
           expected_history = [['start execution', executor_world.id],
-                              ['finish execution', executor_world.id]]
+                              ['pause execution', executor_world.id]]
           plan.execution_history.map { |h| [h.name, h.world_id] }.must_equal(expected_history)
         end
       end

--- a/test/abnormal_states_recovery_test.rb
+++ b/test/abnormal_states_recovery_test.rb
@@ -142,13 +142,7 @@ module Dynflow
       describe 'auto execute' do
 
         before do
-          client_world.persistence.find_execution_plans({}).each do |plan|
-            # make sure we don't handle plans from previous tests
-            # TODO: delete the plans instead, once we have
-            # https://github.com/Dynflow/dynflow/pull/141 merged
-            plan.set_state(:stopped, true)
-            plan.save
-          end
+          client_world.persistence.delete_execution_plans({})
         end
 
         it "prevents from running the auto-execution twice" do

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -138,6 +138,7 @@ module Dynflow
             wait_for('execution plan removed from executor') do
               !director.current_execution_plan_ids.include?(execution_plan.id)
             end
+            world.persistence.find_execution_plans(filters: { uuid: [execution_plan.id] }).must_be :empty?
           end
         end
       end

--- a/test/rescue_test.rb
+++ b/test/rescue_test.rb
@@ -192,6 +192,9 @@ module Dynflow
           it 'skips the action and continues automatically' do
             execution_plan.state.must_equal :paused
             execution_plan.result.must_equal :error
+            expected_history = [['start execution', world.id],
+                                ['pause execution', world.id]]
+            execution_plan.execution_history.map { |h| [h.name, h.world_id] }.must_equal(expected_history)
           end
         end
 
@@ -206,6 +209,9 @@ module Dynflow
             execution_plan.steps_in_state(:success).count.must_equal 6
             execution_plan.steps_in_state(:pending).count.must_equal 6
             execution_plan.steps_in_state(:error).count.must_equal 1
+            expected_history = [['start execution', world.id],
+                                ['finish execution', world.id]]
+            execution_plan.execution_history.map { |h| [h.name, h.world_id] }.must_equal(expected_history)
           end
         end
 

--- a/test/rescue_test.rb
+++ b/test/rescue_test.rb
@@ -15,125 +15,99 @@ module Dynflow
       end
 
       let :rescued_plan do
-        execution_plan.rescue_from_error.value
+        world.persistence.load_execution_plan(execution_plan.id)
       end
 
-      describe 'of simple skippable action in run phase' do
+      describe 'no auto rescue' do
+        describe 'of simple skippable action in run phase' do
 
-        let :execution_plan do
-          execute(Example::ActionWithSkip, 1, :error_on_run)
-        end
-
-        it 'suggests skipping the action' do
-          execution_plan.rescue_strategy.must_equal Action::Rescue::Skip
-        end
-
-        it 'skips the action and continues' do
-          rescued_plan.state.must_equal :stopped
-          rescued_plan.result.must_equal :warning
-          rescued_plan.entry_action.output[:message].
-            must_equal "skipped because some error as you wish"
-        end
-      end
-
-      describe 'of simple skippable action in finalize phase' do
-
-        let :execution_plan do
-          execute(Example::ActionWithSkip, 1, :error_on_finalize)
-        end
-
-        it 'suggests skipping the action' do
-          execution_plan.rescue_strategy.must_equal Action::Rescue::Skip
-        end
-
-        it 'skips the action and continues' do
-          rescued_plan.state.must_equal :stopped
-          rescued_plan.result.must_equal :warning
-          rescued_plan.entry_action.output[:message].must_equal "Been here"
-        end
-
-      end
-
-      describe 'of complex action with skips in run phase' do
-
-        let :execution_plan do
-          execute(Example::ComplexActionWithSkip, :error_on_run)
-        end
-
-        it 'suggests skipping the action' do
-          execution_plan.rescue_strategy.must_equal Action::Rescue::Skip
-        end
-
-        it 'skips the action and continues' do
-          rescued_plan.state.must_equal :stopped
-          rescued_plan.result.must_equal :warning
-          skipped_action = rescued_plan.actions.find do |action|
-            action.run_step && action.run_step.state == :skipped
+          let :execution_plan do
+            execute(Example::ActionWithSkip, 1, :error_on_run)
           end
-          skipped_action.output[:message].must_equal "skipped because some error as you wish"
-        end
 
-      end
-
-      describe 'of complex action with skips in finalize phase' do
-
-        let :execution_plan do
-          execute(Example::ComplexActionWithSkip, :error_on_finalize)
-        end
-
-        it 'suggests skipping the action' do
-          execution_plan.rescue_strategy.must_equal Action::Rescue::Skip
-        end
-
-        it 'skips the action and continues' do
-          # we need to rescue twice for two errors in sequence
-          rescued_plan = execution_plan.rescue_from_error.value
-          rescued_plan = rescued_plan.rescue_from_error.value
-          rescued_plan.state.must_equal :stopped
-          rescued_plan.result.must_equal :warning
-          skipped_action = rescued_plan.actions.find do |action|
-            action.steps.find { |step| step && step.state == :skipped }
+          it 'suggests skipping the action' do
+            execution_plan.rescue_strategy.must_equal Action::Rescue::Skip
           end
-          skipped_action.output[:message].must_equal "Been here"
+
+          it "doesn't rescue" do
+            rescued_plan.state.must_equal :paused
+          end
         end
 
-      end
+        describe 'of simple skippable action in finalize phase' do
 
-      describe 'of complex action without skips' do
+          let :execution_plan do
+            execute(Example::ActionWithSkip, 1, :error_on_finalize)
+          end
 
-        let :execution_plan do
-          execute(Example::ComplexActionWithoutSkip, :error_on_run)
+          it 'suggests skipping the action' do
+            execution_plan.rescue_strategy.must_equal Action::Rescue::Skip
+          end
+
+          it "doesn't rescue" do
+            rescued_plan.state.must_equal :paused
+          end
         end
 
-        it 'suggests pausing the plan' do
-          execution_plan.rescue_strategy.must_equal Action::Rescue::Pause
+        describe 'of complex action with skips in run phase' do
+
+          let :execution_plan do
+            execute(Example::ComplexActionWithSkip, :error_on_run)
+          end
+
+          it 'suggests skipping the action' do
+            execution_plan.rescue_strategy.must_equal Action::Rescue::Skip
+          end
+
+          it "doesn't rescue" do
+            rescued_plan.state.must_equal :paused
+          end
         end
 
-        it 'fails rescuing' do
-          lambda { rescued_plan }.must_raise Errors::RescueError
+        describe 'of complex action with skips in finalize phase' do
+
+          let :execution_plan do
+            execute(Example::ComplexActionWithSkip, :error_on_finalize)
+          end
+
+          it 'suggests skipping the action' do
+            execution_plan.rescue_strategy.must_equal Action::Rescue::Skip
+          end
+
+          it "doesn't rescue" do
+            rescued_plan.state.must_equal :paused
+          end
         end
 
-      end
+        describe 'of complex action without skips' do
 
-      describe 'of complex action with fail' do
+          let :execution_plan do
+            execute(Example::ComplexActionWithoutSkip, :error_on_run)
+          end
 
-        let :execution_plan do
-          execute(Example::ComplexActionWithFail, :error_on_run)
+          it 'suggests pausing the plan' do
+            execution_plan.rescue_strategy.must_equal Action::Rescue::Pause
+          end
+
+          it "doesn't rescue" do
+            rescued_plan.state.must_equal :paused
+          end
         end
 
-        it 'suggests failing the plan' do
-          execution_plan.rescue_strategy.must_equal Action::Rescue::Fail
-        end
+        describe 'of complex action with fail' do
 
-        it 'fails rescuing' do
-          proc { rescued_plan }.must_raise Errors::RescueError
-          execution_plan.state.must_equal :stopped
-          execution_plan.result.must_equal :error
-          execution_plan.steps_in_state(:success).count.must_equal 6
-          execution_plan.steps_in_state(:pending).count.must_equal 6
-          execution_plan.steps_in_state(:error).count.must_equal 1
-        end
+          let :execution_plan do
+            execute(Example::ComplexActionWithFail, :error_on_run)
+          end
 
+          it 'suggests failing the plan' do
+            execution_plan.rescue_strategy.must_equal Action::Rescue::Fail
+          end
+
+          it "doesn't rescue" do
+            rescued_plan.state.must_equal :paused
+          end
+        end
       end
 
       describe 'auto rescue' do
@@ -144,8 +118,32 @@ module Dynflow
           end
         end
 
-        describe 'of plan with skips' do
+        describe 'of simple skippable action in run phase' do
+          let :execution_plan do
+            execute(Example::ActionWithSkip, 1, :error_on_run)
+          end
 
+          it 'skips the action and continues' do
+            rescued_plan.state.must_equal :stopped
+            rescued_plan.result.must_equal :warning
+            rescued_plan.entry_action.output[:message].
+              must_equal "skipped because some error as you wish"
+          end
+        end
+
+        describe 'of simple skippable action in finalize phase' do
+          let :execution_plan do
+            execute(Example::ActionWithSkip, 1, :error_on_finalize)
+          end
+
+          it 'skips the action and continues' do
+            rescued_plan.state.must_equal :stopped
+            rescued_plan.result.must_equal :warning
+            rescued_plan.entry_action.output[:message].must_equal "Been here"
+          end
+        end
+
+        describe 'of plan with skips' do
           let :execution_plan do
             execute(Example::ComplexActionWithSkip, :error_on_run)
           end
@@ -153,12 +151,29 @@ module Dynflow
           it 'skips the action and continues automatically' do
             execution_plan.state.must_equal :stopped
             execution_plan.result.must_equal :warning
+            skipped_action = rescued_plan.actions.find do |action|
+              action.run_step && action.run_step.state == :skipped
+            end
+            skipped_action.output[:message].must_equal "skipped because some error as you wish"
+          end
+        end
+
+        describe 'of complex action with skips in finalize phase' do
+          let :execution_plan do
+            execute(Example::ComplexActionWithSkip, :error_on_finalize)
           end
 
+          it 'skips the action and continues' do
+            rescued_plan.state.must_equal :stopped
+            rescued_plan.result.must_equal :warning
+            skipped_action = rescued_plan.actions.find do |action|
+              action.steps.find { |step| step && step.state == :skipped }
+            end
+            skipped_action.output[:message].must_equal "Been here"
+          end
         end
 
         describe 'of plan faild on auto-rescue' do
-
           let :execution_plan do
             execute(Example::ActionWithSkip, 1, :error_on_skip)
           end
@@ -167,11 +182,9 @@ module Dynflow
             execution_plan.state.must_equal :paused
             execution_plan.result.must_equal :error
           end
-
         end
 
         describe 'of plan without skips' do
-
           let :execution_plan do
             execute(Example::ComplexActionWithoutSkip, :error_on_run)
           end
@@ -180,11 +193,9 @@ module Dynflow
             execution_plan.state.must_equal :paused
             execution_plan.result.must_equal :error
           end
-
         end
 
         describe 'of plan with fail' do
-
           let :execution_plan do
             execute(Example::ComplexActionWithFail, :error_on_run)
           end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -225,11 +225,11 @@ module TestHelpers
   def assert_plan_reexecuted(plan)
     assert_equal :stopped, plan.state
     assert_equal :success, plan.result
-    assert_equal plan.execution_history.map(&:name),
-                 ['start execution',
+    assert_equal ['start execution',
                   'terminate execution',
                   'start execution',
-                  'finish execution']
+                  'finish execution'],
+                 plan.execution_history.map(&:name)
     refute_equal plan.execution_history.first.world_id, plan.execution_history.to_a.last.world_id
   end
 end


### PR DESCRIPTION
The previous rescue algorithm put the task into paused state and then we
looked at what are the possible rescue strategies, and if it was to
skip, we marked the steps to skip and executed the task again.

Several problems where there with this approach:

- the execution plan needed to get back at the beginning of the workers
  queue, so there was additional overhead with this

- the execution history got confusing, because there was note about
  finishing and starting the execution again

- it's hard to hook events (such as logging or notifications) for paused
  tasks, as when the plan was getting into paused state, we didn't know
  it would be rescued immediately.

This is a prerequisite for allowing notifications on paused tasks.