### PR TITLE
Fix intermittent failures around invalid uuid

### DIFF
--- a/test/abnormal_states_recovery_test.rb
+++ b/test/abnormal_states_recovery_test.rb
@@ -318,7 +318,7 @@ module Dynflow
             plan
           end
 
-          let(:sample_uuid) { '60366107-9910-4815-a6c6-bc45ee2ea2b8' }
+          let(:sample_uuid) { '11111111-2222-3333-4444-555555555555' }
           let(:valid_plan) { plan_in_state :running }
           let(:invalid_plan) { plan_in_state :stopped }
           let(:valid_lock)    { Coordinator::SingletonActionLock.new('MyClass1', valid_plan.id) }


### PR DESCRIPTION
Using the same plan uuid in two tests doesn't seem like a good idea.
Setting the uuid in abnormal_states_recovery_test to be different
than the one in execution_plan_test.rb

Combination of https://github.com/Dynflow/dynflow/pull/319 and https://github.com/Dynflow/dynflow/pull/317
lead to issues like:

```
consistency check::#coordinator_validity_check::with singleton action locks#test_0001_unlocks orphaned singleton action locks
[/home/travis/build/Dynflow/dynflow/test/abnormal_states_recovery_test.rb:335]:
Expected [#<Dynflow::Coordinator::SingletonActionLock:0x000000056f2200 @data={"class"=>"Dynflow::Coordinator::SingletonActionLock", "owner_id"=>"execution-plan:98ddd0fa-5ba9-44a6-b72d-2ad8b05dc802", "execution_plan_id"=>"98ddd0fa-5ba9-44a6-b72d-2ad8b05dc802", "id"=>"singleton-action:MyClass3"}, @from_hash=true>] to include #<Dynflow::Coordinator::SingletonActionLock:0x000000057cd170 @data={"class"=>"Dynflow::Coordinator::SingletonActionLock", "owner_id"=>"execution-plan:60366107-9910-4815-a6c6-bc45ee2ea2b8", "execution_plan_id"=>"60366107-9910-4815-a6c6-bc45ee2ea2b8", "id"=>"singleton-action:MyClass2"}>.
```

See https://travis-ci.org/Dynflow/dynflow/jobs/498756571