### PR TITLE
Support for logger message with block

### DIFF
--- a/lib/dynflow/logger_adapters/formatters/abstract.rb
+++ b/lib/dynflow/logger_adapters/formatters/abstract.rb
@@ -7,7 +7,7 @@ module Dynflow
         end
 
         [:fatal, :error, :warn, :info, :debug].each do |method|
-          define_method method do |message, &block|
+          define_method method do |message = nil, &block|
             if block
               @base.send method, &-> { format(block.call) }
             else

--- a/lib/dynflow/logger_adapters/simple.rb
+++ b/lib/dynflow/logger_adapters/simple.rb
@@ -41,7 +41,7 @@ module Dynflow
         end
 
         { fatal: 4, error: 3, warn: 2, info: 1, debug: 0 }.each do |method, level|
-          define_method method do |message, &block|
+          define_method method do |message = nil, &block|
             @logger.add level, message, @prog_name, &block
           end
         end


### PR DESCRIPTION
Before this patch, we couldn't do things like this:

    logger.debug { "Message that needs some calculation" }