### PR TITLE
Fix pause hooks + refactor history notices

### DIFF
--- a/lib/dynflow/delayed_plan.rb
+++ b/lib/dynflow/delayed_plan.rb
@@ -34,15 +34,13 @@ module Dynflow
       execution_plan.root_plan_step.state = :error
       execution_plan.root_plan_step.error = ::Dynflow::ExecutionPlan::Steps::Error.new(message)
       execution_plan.root_plan_step.save
-      execution_plan.execution_history.add history_entry, @world.id unless history_entry.nil?
-      execution_plan.update_state :stopped
+      execution_plan.update_state :stopped, history_notice: history_entry
     end
 
     def cancel
       execution_plan.root_plan_step.state = :cancelled
       execution_plan.root_plan_step.save
-      execution_plan.execution_history.add "Delayed task cancelled", @world.id
-      execution_plan.update_state :stopped
+      execution_plan.update_state :stopped, history_notice: "Delayed task cancelled"
       @world.persistence.delete_delayed_plans(:execution_plan_uuid => @execution_plan_uuid)
       return true
     end

--- a/lib/dynflow/director.rb
+++ b/lib/dynflow/director.rb
@@ -187,7 +187,7 @@ module Dynflow
       if new_state == :running
         return manager.restart
       else
-        manager.execution_plan.state = new_state
+        manager.execution_plan.update_state(new_state)
         return false
       end
     end
@@ -217,20 +217,12 @@ module Dynflow
       case execution_plan.state
       when :running
         if execution_plan.error?
-          execution_plan.execution_history.add('pause execution', @world.id)
           execution_plan.update_state(:paused)
         elsif manager.done?
-          execution_plan.execution_history.add('finish execution', @world.id)
           execution_plan.update_state(:stopped)
         end
         # If the state is marked as running without errors but manager is not done,
         # we let the invalidation procedure to handle re-execution on other executor
-      when :paused
-        execution_plan.execution_history.add('pause execution', @world.id)
-        execution_plan.save
-      when :stopped
-        execution_plan.execution_history.add('finish execution', @world.id)
-        execution_plan.save
       end
     end
 

--- a/lib/dynflow/director/execution_plan_manager.rb
+++ b/lib/dynflow/director/execution_plan_manager.rb
@@ -15,7 +15,6 @@ module Dynflow
         unless [:planned, :paused].include? execution_plan.state
           raise "execution_plan is not in pending or paused state, it's #{execution_plan.state}"
         end
-        execution_plan.execution_history.add('start execution', @world.id)
         execution_plan.update_state(:running)
       end
 

--- a/lib/dynflow/world/invalidation.rb
+++ b/lib/dynflow/world/invalidation.rb
@@ -33,8 +33,6 @@ module Dynflow
       # @return [void]
       def invalidate_execution_lock(execution_lock)
         with_valid_execution_plan_for_lock(execution_lock) do |plan|
-          plan.execution_history.add('terminate execution', execution_lock.world_id)
-
           plan.steps.values.each do |step|
             if step.state == :running
               step.error = ExecutionPlan::Steps::Error.new("Abnormal termination (previous state: #{step.state})")
@@ -43,7 +41,8 @@ module Dynflow
             end
           end
 
-          plan.update_state(:paused) if plan.state == :running
+          plan.execution_history.add('terminate execution', execution_lock.world_id)
+          plan.update_state(:paused, history_notice: false) if plan.state == :running
           plan.save
           coordinator.release(execution_lock)
 


### PR DESCRIPTION
After 8bae5b62b273, we had a code that was updating `state` outside of
`update_state` method, which meant the hooks (observed with `:paused`
state) were not run when `auto_rescue` was enabled.

I've also noticed coupling between adding history and `update_state`
methods, so I put it directly into `update_state`.