### PR TITLE
Log the original trace for the actor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,7 @@ sudo: false
 language:
   - ruby
 
-before_install: >-
-  if ruby -v | grep 'ruby 2.2'; then
-    gem install bundler -v '~> 1.17'
-  fi
-
 rvm:
-  - "2.2.2"
   - "2.3.1"
   - "2.4.0"
   - "2.5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -12,24 +12,11 @@ group :pry do
 end
 
 group :postgresql do
-  if RUBY_VERSION <= '2'
-    gem 'pg', '< 0.19'
-  else
-    gem "pg"
-  end
+  gem "pg"
 end
 
 group :mysql do
   gem "mysql2"
-end
-
-if RUBY_VERSION < "2.2.2"
-  gem 'activesupport', '~> 4.2'
-  gem 'sinatra', '~> 1.4.8'
-end
-
-if RUBY_VERSION < '2.3.0'
-  gem 'i18n', '<= 1.5.1'
 end
 
 group :lint do

--- a/dynflow.gemspec
+++ b/dynflow.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.3.0'
 
   s.add_dependency "multi_json"
   s.add_dependency "apipie-params"

--- a/lib/dynflow/actor.rb
+++ b/lib/dynflow/actor.rb
@@ -7,10 +7,82 @@ module Dynflow
     end
   end
 
+  # Extend the Concurrent::Actor::Envelope to include information about the origin of the message
+  module EnvelopeBacktraceExtension
+    def initialize(*args)
+      super
+      @origin_backtrace = caller + Actor::BacktraceCollector.current_actor_backtrace
+    end
+
+    def origin_backtrace
+      @origin_backtrace
+    end
+
+    def inspect
+      "#<#{self.class.name}:#{object_id}> @message=#{@message.inspect}, @sender=#{@sender.inspect}, @address=#{@address.inspect}>"
+    end
+  end
+  Concurrent::Actor::Envelope.prepend(EnvelopeBacktraceExtension)
+
   # Common parent for all the Dynflow actors defining some defaults
   # that we preffer here.
   class Actor < Concurrent::Actor::Context
+    module LogWithFullBacktrace
+      def log(level, message = nil, &block)
+        if message.is_a? Exception
+          error = message
+          backtrace = Actor::BacktraceCollector.full_backtrace(error.backtrace)
+          log(level, format("%s (%s)\n%s", error.message, error.class, backtrace.join("\n")))
+        else
+          super
+        end
+      end
+    end
 
+    class SetResultsWithOriginLogging < Concurrent::Actor::Behaviour::SetResults
+      include LogWithFullBacktrace
+
+      def on_envelope(envelope)
+        Actor::BacktraceCollector.with_backtrace(envelope.origin_backtrace) { super }
+      end
+    end
+
+    class BacktraceCollector
+      CONCURRENT_RUBY_LINE = '[ concurrent-ruby ]'.freeze
+
+      class << self
+        def with_backtrace(backtrace)
+          previous_actor_backtrace = Thread.current[:_dynflow_actor_backtrace]
+          Thread.current[:_dynflow_actor_backtrace] = backtrace
+          yield
+        ensure
+          Thread.current[:_dynflow_actor_backtrace] = previous_actor_backtrace
+        end
+
+        def current_actor_backtrace
+          Thread.current[:_dynflow_actor_backtrace] || []
+        end
+
+        def full_backtrace(backtrace)
+          filter_backtrace((backtrace || []) + current_actor_backtrace)
+        end
+
+        private
+
+        def filter_line?(line)
+          %w[concurrent-ruby gems/logging actor.rb].any? { |pattern| line.include?(pattern) }
+        end
+
+        # takes an array of backtrace lines and replaces each chunk
+        def filter_backtrace(backtrace)
+          backtrace.map { |line| filter_line?(line) ? CONCURRENT_RUBY_LINE : line }
+            .chunk_while { |l1, l2| l1.equal?(CONCURRENT_RUBY_LINE) && l2.equal?(CONCURRENT_RUBY_LINE) }
+            .map(&:first)
+        end
+      end
+    end
+
+    include LogWithFullBacktrace
     include MethodicActor
 
     # Behaviour that watches for polite asking for termination
@@ -46,7 +118,7 @@ module Dynflow
     def behaviour_definition
       [*Concurrent::Actor::Behaviour.base(:just_log),
        Concurrent::Actor::Behaviour::Buffer,
-       [Concurrent::Actor::Behaviour::SetResults, :just_log],
+       [SetResultsWithOriginLogging, :just_log],
        Concurrent::Actor::Behaviour::Awaits,
        PoliteTermination,
        Concurrent::Actor::Behaviour::ExecutesContext,

--- a/lib/dynflow/logger_adapters/formatters/exception.rb
+++ b/lib/dynflow/logger_adapters/formatters/exception.rb
@@ -4,7 +4,8 @@ module Dynflow
       class Exception < Abstract
         def format(message)
           if ::Exception === message
-            "#{message.message} (#{message.class})\n#{message.backtrace.join("\n")}"
+            backtrace = Actor::BacktraceCollector.full_backtrace(message.backtrace)
+            "#{message.message} (#{message.class})\n#{backtrace.join("\n")}"
           else
             message
           end


### PR DESCRIPTION
This helps a lot figuring out where the particular errors are coming
from.

Before - long backtrace that doesn't lead to the original caller:

```
E, [2019-05-25T22:12:00.588309 #13630] ERROR -- /client-dispatcher: No executor available (Dynflow::Error)
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/connectors/direct.rb:44:in `find_receiver'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/connectors/direct.rb:29:in `handle_envelope'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/actor.rb:6:in `on_message'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/context.rb:46:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/executes_context.rb:7:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/actor.rb:26:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/awaits.rb:15:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/sets_results.rb:14:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/buffer.rb:38:in `process_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/buffer.rb:31:in `process_envelopes?'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/buffer.rb:20:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/termination.rb:55:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/removes_child.rb:10:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/sets_results.rb:14:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/core.rb:162:in `process_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/core.rb:96:in `block in on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/core.rb:119:in `block (2 levels) in schedule_execution'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/synchronization/mutex_lockable_object.rb:41:in `block in synchronize'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/synchronization/mutex_lockable_object.rb:41:in `synchronize'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/synchronization/mutex_lockable_object.rb:41:in `synchronize'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/core.rb:116:in `block in schedule_execution'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/serialized_execution.rb:18:in `call'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/serialized_execution.rb:96:in `work'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/serialized_execution.rb:77:in `block in call_job'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:348:in `run_task'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:337:in `block (3 levels) in create_worker'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:320:in `loop'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:320:in `block (2 levels) in create_worker'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:319:in `catch'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:319:in `block in create_worker'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/promises.rb:1257:in `raise'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/promises.rb:1257:in `wait_until_resolved!'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/promises.rb:987:in `value!'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/dispatcher/client_dispatcher.rb:148:in `dispatch_request'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/actor.rb:6:in `on_message'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/context.rb:46:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/executes_context.rb:7:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/actor.rb:26:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/awaits.rb:15:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/sets_results.rb:14:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/buffer.rb:38:in `process_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/buffer.rb:31:in `process_envelopes?'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/buffer.rb:20:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/termination.rb:55:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/removes_child.rb:10:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/abstract.rb:25:in `pass'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/behaviour/sets_results.rb:14:in `on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/core.rb:162:in `process_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/core.rb:96:in `block in on_envelope'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/core.rb:119:in `block (2 levels) in schedule_execution'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/synchronization/mutex_lockable_object.rb:41:in `block in synchronize'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/synchronization/mutex_lockable_object.rb:41:in `synchronize'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/synchronization/mutex_lockable_object.rb:41:in `synchronize'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-edge-0.4.1/lib-edge/concurrent/actor/core.rb:116:in `block in schedule_execution'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/serialized_execution.rb:18:in `call'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/serialized_execution.rb:96:in `work'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/serialized_execution.rb:77:in `block in call_job'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:348:in `run_task'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:337:in `block (3 levels) in create_worker'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:320:in `loop'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:320:in `block (2 levels) in create_worker'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:319:in `catch'
/home/inecas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.1.5/lib/concurrent/executor/ruby_thread_pool_executor.rb:319:in `block in create_worker'
```

After - the concurrent-ruby part is filtered out, and the original backtrace back to the initiator
is included, including jumps though multiple actors:

```
E, [2019-05-25T22:06:56.311751 #11038] ERROR -- /connector-direct-core: No executor available (Dynflow::Error)
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/connectors/direct.rb:44:in `find_receiver'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/connectors/direct.rb:29:in `handle_envelope'
[ concurrent-ruby ]
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/connectors/direct.rb:68:in `send'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/dispatcher/client_dispatcher.rb:148:in `dispatch_request'
[ concurrent-ruby ]
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/world/invalidation.rb:54:in `block in invalidate_execution_lock'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/world/invalidation.rb:94:in `with_valid_execution_plan_for_lock'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/world/invalidation.rb:35:in `invalidate_execution_lock'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/dispatcher/executor_dispatcher.rb:38:in `when_done'
/home/inecas/active/projects/foreman-main/dynflow/lib/dynflow/dispatcher/executor_dispatcher.rb:23:in `block (2 levels) in perform_execution'
[ concurrent-ruby ]
```

FYI there is a track to propagate the backtraces within concurrent-ruby executor here https://github.com/ruby-concurrency/concurrent-ruby/issues/810