### PR TITLE
 Allow running multiple orchestrators in active-passive mode

### DIFF
--- a/lib/dynflow/executors/sidekiq/redis_locking.rb
+++ b/lib/dynflow/executors/sidekiq/redis_locking.rb
@@ -1,0 +1,68 @@
+module Dynflow
+  module Executors
+    module Sidekiq
+      module RedisLocking
+        REDIS_LOCK_KEY = 'dynflow_orchestrator_uuid'
+        REDIS_LOCK_TTL = 60
+        REDIS_LOCK_POLL_INTERVAL = 15
+
+        ACQUIRE_OK = 0
+        ACQUIRE_MISSING = 1
+        ACQUIRE_TAKEN = 2
+
+        RELEASE_SCRIPT = <<~LUA
+          if redis.call("get", KEYS[1]) == ARGV[1] then
+            redis.call("del", KEYS[1])
+          end
+          return #{ACQUIRE_OK}
+        LUA
+
+        REACQUIRE_SCRIPT = <<~LUA
+          if redis.call("exists", KEYS[1]) == 1 then
+            local owner = redis.call("get", KEYS[1])
+            if owner == ARGV[1] then
+              redis.call("set", KEYS[1], ARGV[1], "XX", "EX", #{REDIS_LOCK_TTL})
+              return #{ACQUIRE_OK}
+            else
+              return #{ACQUIRE_TAKEN}
+            end
+          else
+            redis.call("set", KEYS[1], ARGV[1], "NX", "EX", #{REDIS_LOCK_TTL})
+            return #{ACQUIRE_MISSING}
+          end
+        LUA
+
+        def release_orchestrator_lock
+          ::Sidekiq.redis { |conn| conn.eval RELEASE_SCRIPT, [REDIS_LOCK_KEY], [@world.id] }
+        end
+
+        def wait_for_orchestrator_lock
+          mode = nil
+          loop do
+            active = ::Sidekiq.redis do |conn|
+              conn.set(REDIS_LOCK_KEY, @world.id, :ex => REDIS_LOCK_TTL, :nx => true)
+            end
+            break if active
+            if mode.nil?
+              mode = :passive
+              @logger.info('Orchestrator lock already taken, entering passive mode.')
+            end
+            sleep REDIS_LOCK_POLL_INTERVAL
+          end
+          @logger.info('Acquired orchestrator lock, entering active mode.')
+        end
+
+        def reacquire_orchestrator_lock
+          case ::Sidekiq.redis { |conn| conn.eval REACQUIRE_SCRIPT, [REDIS_LOCK_KEY], [@world.id] }
+          when ACQUIRE_MISSING
+            @logger.error('The orchestrator lock was lost, reacquired')
+          when ACQUIRE_TAKEN
+            owner = ::Sidekiq.redis { |conn| conn.get REDIS_LOCK_KEY }
+            @logger.fatal("The orchestrator lock was stolen by #{owner}, aborting.")
+            Process.kill('INT', Process.pid)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dynflow/executors/sidekiq/redis_locking.rb
+++ b/lib/dynflow/executors/sidekiq/redis_locking.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Dynflow
   module Executors
     module Sidekiq

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -9,6 +9,14 @@ require 'sidekiq/testing'
 ::Sidekiq::Testing::inline!
 require 'dynflow/executors/sidekiq/core'
 
+module RedisMocks
+  def release_orchestrator_lock; end
+  def wait_for_orchestrator_lock; end
+  def reacquire_orchestrator_lock; end
+end
+
+::Dynflow::Executors::Sidekiq::Core.send(:prepend, RedisMocks)
+
 module Dynflow
   module ExecutorTest
     [::Dynflow::Executors::Parallel::Core, ::Dynflow::Executors::Sidekiq::Core].each do |executor|


### PR DESCRIPTION
Upon startup, the orchestrator checks if dynflow_orchestrator_uuid key is unset in Redis. If so, it acquires an orchestrator lock by associating the uuid of the orchestrator's world with the key. However this lock has limited time to live and needs to be periodically
refreshed.

If the key is set, the orchestrator goes into passive mode and periodically polls the lock's status. If it manages to acquire the lock, it becomes the active orchestrator.

Active orchestrator periodically updates the record in Redis to ensure its freshness.

Redmine: https://projects.theforeman.org/issues/27412