### PR TITLE
Handle cases where worker is shut down

### DIFF
--- a/examples/remote_executor.rb
+++ b/examples/remote_executor.rb
@@ -79,6 +79,10 @@ class RemoteExecutorExample
         # Use semi-reliable fetch
         # for details see https://gitlab.com/gitlab-org/sidekiq-reliable-fetch/blob/master/README.md
         config.options[:semi_reliable_fetch] = true
+        # Do not requeue jobs after sidekiq shutdown
+        config.options[:max_retries_after_interruption] = 0
+        # Do not store interrupted jobs, just discard them
+        config.options[:interrupted_max_jobs] = 0
         Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
       end
       ExampleHelper.create_world do |config|


### PR DESCRIPTION
If the worker is shut down, execution of its work item is interrupted, but it
still sends the work done job to the orchestrator and requeues the job to be
executed again. This leads to two issues - step is not saved after the worker is
interrupted and the job is executed twice.

This patch disables the job requeueing and makes orchestrator save the step, if
the step's error is ::Sidekiq::Shutdown. This solves both of the issues.

If the worker is not interrupted, but is SIGKILLed, then the regular worker
crash handling kicks in, reruns the job and the it fails because the step is in
an unexpected state.

For example usage see https://github.com/Dynflow/dynflow/compare/master...adamruzicka:abnormal-termination-example?expand=1