### PR TITLE
Properly detect which executor core to use

### DIFF
--- a/lib/dynflow/rails/configuration.rb
+++ b/lib/dynflow/rails/configuration.rb
@@ -168,7 +168,7 @@ module Dynflow
         if remote?
           false
         else
-          if defined?(::Sidekiq) && !Sidekiq.options[:dynflow_world].nil?
+          if defined?(::Sidekiq) && Sidekiq.options[:dynflow_executor]
             ::Dynflow::Executors::Sidekiq::Core
           else
             ::Dynflow::Executors::Parallel::Core


### PR DESCRIPTION
We used to check if `Sidekiq.options[:dynflow_executor]` is not nil, but in
rails this was being set after the world was initialized. That led to Parallel
core being used instead of Sidekiq one.