### PR TITLE
Fix Sequel::DatabaseError during migrations

### DIFF
--- a/lib/dynflow/persistence_adapters/sequel_migrations/001_initial.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/001_initial.rb
@@ -32,7 +32,8 @@ Sequel.migration do
       primary_key [:execution_plan_uuid, :id]
       index [:execution_plan_uuid, :id], :unique => true
       column :action_id, Integer
-      foreign_key [:execution_plan_uuid, :action_id], :dynflow_actions
+      foreign_key [:execution_plan_uuid, :action_id], :dynflow_actions,
+                  name: :dynflow_steps_execution_plan_uuid_fkey1
       index [:execution_plan_uuid, :action_id]
 
       column :data, String, text: true


### PR DESCRIPTION
The full error was:
```
Sequel::DatabaseError: PG::UndefinedObject: ERROR: constraint
"dynflow_steps_execution_plan_uuid_fkey1" of relation "dynflow_steps" does not
exist
```

It turned out PostgreSQL names foreign key constraints differently than previous
versions. This could cause issues when we try to migrate string columns to
UUIDs, because we have to temporarily remove specific foreign key constraints
which didn't exist due to the new naming scheme. To solve this, this patch
"hard-codes" the names of foreign key constraints which we need to touch.