### PR TITLE
Add a unique constraint to column execution_plan_uuid of table dynflow_actions

### DIFF
--- a/lib/dynflow/persistence_adapters/sequel_migrations/021_add_unique_constraint_dynflow_actions_execution_plan_uuid_ukey.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/021_add_unique_constraint_dynflow_actions_execution_plan_uuid_ukey.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+Sequel.migration do
+  up do
+    alter_table :dynflow_actions do
+      add_unique_constraint [:execution_plan_uuid], name: :dynflow_actions_execution_plan_uuid_ukey
+    end
+  end
+
+  down do
+    alter_table :dynflow_actions do
+      drop_constraint :dynflow_actions_execution_plan_uuid_ukey
+    end
+  end
+end


### PR DESCRIPTION
It seems that unique constraint on `execution_plan_uuid` column of `dynflow_actions` table is missing. For this reason, Foreman plugin tests fails with error:

```
PG::InvalidForeignKey: ERROR:  there is no unique constraint matching given keys for referenced table "dynflow_actions"
```
- Foreman branch: `develop`
- dynflow version: `1.4.4`

See https://github.com/kamils-iRonin/foreman_vault/runs/668518086?check_suite_focus=true for more details.

And with this fix: https://github.com/kamils-iRonin/foreman_vault/runs/668518111?check_suite_focus=true