### PR TITLE
Do not instantiate an exception to check its class

### DIFF
--- a/lib/dynflow/executors/sidekiq/orchestrator_jobs.rb
+++ b/lib/dynflow/executors/sidekiq/orchestrator_jobs.rb
@@ -13,7 +13,7 @@ module Dynflow
           def perform(work_item, delayed_events = nil)
             # Usually the step is saved on the worker's side. However if sidekiq is shut down,
             #   then the step may not have been saved so we save it just to be sure
-            if work_item.is_a?(Director::StepWorkItem) && work_item.step&.error&.exception.is_a?(::Sidekiq::Shutdown)
+            if work_item.is_a?(Director::StepWorkItem) && work_item.step&.error&.exception_class == ::Sidekiq::Shutdown
               work_item.step.save
             end
             Dynflow.process_world.executor.core.tell([:work_finished, work_item, delayed_events])


### PR DESCRIPTION
When the worker is stopped, ::Sidekiq::Shutdown exception is raised
inside the worker. In case that happens, we need to save the step on
from the orchestrator's side to not lose data and progress. That means
we have to check every single step if it has an error and if so, what
kind of error it was. Originally we checked whether the exception is
an instance of ::Sidekiq::Shutdown. This commit changes this behavior
to not check the instance, but the class itself.

This may not work if the class is a subclass of the class we're
checking for, but given we expect one specific exception class, I'd
say this is safe to do.