### PR TITLE
Use correct method name for resolving events

### DIFF
--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -341,7 +341,7 @@ module Dynflow
         @terminating = Concurrent::Promises.future do
           termination_future.wait(termination_timeout)
         end.on_resolution do
-          @terminated.complete
+          @terminated.resolve
           Thread.new { Kernel.exit } if @exit_on_terminate.true?
         end
       end


### PR DESCRIPTION
Concurrent-ruby-1.1.3 changed a lot of method names around futures and
events. Apparently we missed one of those when adjusting the code to be
compatible with this version.