### PR TITLE
Store flow data in a more compact manner

### DIFF
--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -422,7 +422,7 @@ module Dynflow
       if flow_hash.is_a? Hash
         Flows::Abstract.from_hash(flow_hash)
       else
-        Flows::Abstract.new_from_hash(flow_hash)
+        Flows::Abstract.decode(flow_hash)
       end
     end
 
@@ -433,8 +433,8 @@ module Dynflow
                         state:             state,
                         result:            result,
                         root_plan_step_id: root_plan_step && root_plan_step.id,
-                        run_flow:          run_flow,
-                        finalize_flow:     finalize_flow,
+                        run_flow:          run_flow.encode,
+                        finalize_flow:     finalize_flow.encode,
                         step_ids:          steps.map { |id, _| id },
                         started_at:        time_to_str(started_at),
                         ended_at:          time_to_str(ended_at),

--- a/lib/dynflow/execution_plan.rb
+++ b/lib/dynflow/execution_plan.rb
@@ -418,6 +418,14 @@ module Dynflow
       end
     end
 
+    def self.load_flow(flow_hash)
+      if flow_hash.is_a? Hash
+        Flows::Abstract.from_hash(flow_hash)
+      else
+        Flows::Abstract.new_from_hash(flow_hash)
+      end
+    end
+
     def to_hash
       recursive_to_hash id:                id,
                         class:             self.class.to_s,
@@ -448,8 +456,8 @@ module Dynflow
                hash[:label],
                hash[:state],
                steps[hash[:root_plan_step_id]],
-               Flows::Abstract.from_hash(hash[:run_flow]),
-               Flows::Abstract.from_hash(hash[:finalize_flow]),
+               load_flow(hash[:run_flow]),
+               load_flow(hash[:finalize_flow]),
                steps,
                string_to_time(hash[:started_at]),
                string_to_time(hash[:ended_at]),

--- a/lib/dynflow/flows.rb
+++ b/lib/dynflow/flows.rb
@@ -4,6 +4,7 @@ require 'forwardable'
 module Dynflow
   module Flows
 
+    require 'dynflow/flows/registry'
     require 'dynflow/flows/abstract'
     require 'dynflow/flows/atom'
     require 'dynflow/flows/abstract_composed'

--- a/lib/dynflow/flows/abstract.rb
+++ b/lib/dynflow/flows/abstract.rb
@@ -41,14 +41,7 @@ module Dynflow
           Flows::Atom.new(hash)
         else
           kind, *subflows = hash
-          klass = case kind
-                  when "S"
-                    Sequence
-                  when "C"
-                    Concurrence
-                  else
-                    raise("Unknown composed flow type")
-                  end
+          klass = AbstractComposed::FLOW_SERIALIZATION_MAP[kind] || raise("Unknown composed flow type")
           klass.new(subflows.map { |subflow| self.new_from_hash(subflow) })
         end
       end

--- a/lib/dynflow/flows/abstract.rb
+++ b/lib/dynflow/flows/abstract.rb
@@ -41,8 +41,7 @@ module Dynflow
           Flows::Atom.new(hash)
         else
           kind, *subflows = hash
-          klass = AbstractComposed::FLOW_SERIALIZATION_MAP[kind] || raise("Unknown composed flow type")
-          klass.new(subflows.map { |subflow| self.new_from_hash(subflow) })
+          Registry.decode(kind).new(subflows.map { |subflow| self.new_from_hash(subflow) })
         end
       end
     end

--- a/lib/dynflow/flows/abstract.rb
+++ b/lib/dynflow/flows/abstract.rb
@@ -34,14 +34,16 @@ module Dynflow
       end
 
       def self.new_from_hash(hash)
-        if hash.is_a? Hash
-          check_class_matching hash
-          new(hash[:flows].map { |flow_hash| from_hash(flow_hash) })
-        elsif hash.is_a? Integer
-          Flows::Atom.new(hash)
+        check_class_matching hash
+        new(hash[:flows].map { |flow_hash| from_hash(flow_hash) })
+      end
+
+      def self.decode(data)
+        if data.is_a? Integer
+          Flows::Atom.new(data)
         else
-          kind, *subflows = hash
-          Registry.decode(kind).new(subflows.map { |subflow| self.new_from_hash(subflow) })
+          kind, *subflows = data
+          Registry.decode(kind).new(subflows.map { |subflow| self.decode(subflow) })
         end
       end
     end

--- a/lib/dynflow/flows/abstract.rb
+++ b/lib/dynflow/flows/abstract.rb
@@ -32,6 +32,26 @@ module Dynflow
       def flatten!
         raise NotImplementedError
       end
+
+      def self.new_from_hash(hash)
+        if hash.is_a? Hash
+          check_class_matching hash
+          new(hash[:flows].map { |flow_hash| from_hash(flow_hash) })
+        elsif hash.is_a? Integer
+          Flows::Atom.new(hash)
+        else
+          kind, *subflows = hash
+          klass = case kind
+                  when "S"
+                    Sequence
+                  when "C"
+                    Concurrence
+                  else
+                    raise("Unknown composed flow type")
+                  end
+          klass.new(subflows.map { |subflow| self.new_from_hash(subflow) })
+        end
+      end
     end
   end
 end

--- a/lib/dynflow/flows/abstract_composed.rb
+++ b/lib/dynflow/flows/abstract_composed.rb
@@ -3,8 +3,6 @@ module Dynflow
   module Flows
     class AbstractComposed < Abstract
 
-      FLOW_SERIALIZATION_MAP = {}
-
       attr_reader :flows
 
       def initialize(flows)
@@ -14,8 +12,7 @@ module Dynflow
       end
 
       def to_hash
-        identifier = FLOW_SERIALIZATION_MAP.invert[self.class] || raise("Unknown composed flow type")
-        [identifier] + flows.map(&:to_hash)
+        [Registry.encode(self)] + flows.map(&:to_hash)
       end
 
       def <<(v)

--- a/lib/dynflow/flows/abstract_composed.rb
+++ b/lib/dynflow/flows/abstract_composed.rb
@@ -11,8 +11,8 @@ module Dynflow
         @flows = flows
       end
 
-      def to_hash
-        [Registry.encode(self)] + flows.map(&:to_hash)
+      def encode
+        [Registry.encode(self)] + flows.map(&:encode)
       end
 
       def <<(v)

--- a/lib/dynflow/flows/abstract_composed.rb
+++ b/lib/dynflow/flows/abstract_composed.rb
@@ -12,7 +12,15 @@ module Dynflow
       end
 
       def to_hash
-        super.merge recursive_to_hash(:flows => flows)
+        identifier = case self
+                     when Sequence
+                       "S"
+                     when Concurrence
+                       "C"
+                     else
+                       raise("Unknown composed flow type")
+                     end
+        [identifier] + flows.map(&:to_hash)
       end
 
       def <<(v)
@@ -60,11 +68,6 @@ module Dynflow
       end
 
       protected
-
-      def self.new_from_hash(hash)
-        check_class_matching hash
-        new(hash[:flows].map { |flow_hash| from_hash(flow_hash) })
-      end
 
       # adds the +new_flow+ in a way that it's in sequence with
       # the +satisfying_flows+

--- a/lib/dynflow/flows/abstract_composed.rb
+++ b/lib/dynflow/flows/abstract_composed.rb
@@ -3,6 +3,8 @@ module Dynflow
   module Flows
     class AbstractComposed < Abstract
 
+      FLOW_SERIALIZATION_MAP = {}
+
       attr_reader :flows
 
       def initialize(flows)
@@ -12,14 +14,7 @@ module Dynflow
       end
 
       def to_hash
-        identifier = case self
-                     when Sequence
-                       "S"
-                     when Concurrence
-                       "C"
-                     else
-                       raise("Unknown composed flow type")
-                     end
+        identifier = FLOW_SERIALIZATION_MAP.invert[self.class] || raise("Unknown composed flow type")
         [identifier] + flows.map(&:to_hash)
       end
 

--- a/lib/dynflow/flows/atom.rb
+++ b/lib/dynflow/flows/atom.rb
@@ -5,7 +5,7 @@ module Dynflow
 
       attr_reader :step_id
 
-      def to_hash
+      def encode
         step_id
       end
 

--- a/lib/dynflow/flows/atom.rb
+++ b/lib/dynflow/flows/atom.rb
@@ -6,7 +6,7 @@ module Dynflow
       attr_reader :step_id
 
       def to_hash
-        super.merge(:step_id => step_id)
+        step_id
       end
 
       def initialize(step_id)

--- a/lib/dynflow/flows/concurrence.rb
+++ b/lib/dynflow/flows/concurrence.rb
@@ -26,6 +26,6 @@ module Dynflow
       end
     end
 
-    AbstractComposed::FLOW_SERIALIZATION_MAP.update('C' => Concurrence)
+    Registry.register!(Concurrence, 'C')
   end
 end

--- a/lib/dynflow/flows/concurrence.rb
+++ b/lib/dynflow/flows/concurrence.rb
@@ -25,5 +25,7 @@ module Dynflow
         return Concurrence.new(extracted_sub_flows)
       end
     end
+
+    AbstractComposed::FLOW_SERIALIZATION_MAP.update('C' => Concurrence)
   end
 end

--- a/lib/dynflow/flows/registry.rb
+++ b/lib/dynflow/flows/registry.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+module Dynflow
+  module Flows
+    class Registry
+      class IdentifierTaken < ArgumentError; end
+      class UnknownIdentifier < ArgumentError; end
+
+      class << self
+        def register!(klass, identifier)
+          if (found = serialization_map[identifier])
+            raise IdentifierTaken, "Error setting up mapping #{identifier} to #{klass}, it already maps to #{found}"
+          else
+            serialization_map.update(identifier => klass)
+          end
+        end
+
+        def encode(klass)
+          klass = klass.class unless klass.is_a?(Class)
+          serialization_map.invert[klass] || raise(UnknownIdentifier, "Could not find mapping for #{klass}")
+        end
+
+        def decode(identifier)
+          serialization_map[identifier] || raise(UnknownIdentifier, "Could not find mapping for #{identifier}")
+        end
+
+        def serialization_map
+          @serialization_map ||= {}
+        end
+      end
+    end
+  end
+end

--- a/lib/dynflow/flows/sequence.rb
+++ b/lib/dynflow/flows/sequence.rb
@@ -11,6 +11,6 @@ module Dynflow
       end
     end
 
-    AbstractComposed::FLOW_SERIALIZATION_MAP.update('S' => Sequence)
+    Registry.register!(Sequence, 'S')
   end
 end

--- a/lib/dynflow/flows/sequence.rb
+++ b/lib/dynflow/flows/sequence.rb
@@ -10,5 +10,7 @@ module Dynflow
         self << dependent_flow
       end
     end
+
+    AbstractComposed::FLOW_SERIALIZATION_MAP.update('S' => Sequence)
   end
 end

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -394,7 +394,7 @@ module Dynflow
 
       def dump_data(value)
         return if value.nil?
-        MultiJson.dump Type!(value, Hash, Array)
+        MultiJson.dump Type!(value, Hash, Array, Integer)
       end
 
       def paginate(data_set, options)

--- a/test/flows_test.rb
+++ b/test/flows_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require_relative 'test_helper'
+require 'mocha/minitest'
+
+module Dynflow
+  describe 'flow' do
+
+    class TestRegistry < Flows::Registry
+      class << self
+        def reset!
+          @serialization_map = {}
+        end
+      end
+    end
+
+    after do
+      TestRegistry.reset!
+    end
+
+    describe "registry" do
+      it "allows registering values" do
+        TestRegistry.register!(TestRegistry, 'TS')
+        TestRegistry.register!(Integer, 'I')
+        map = TestRegistry.instance_variable_get("@serialization_map")
+        _(map).must_equal({'TS' => TestRegistry, 'I' => Integer})
+      end
+
+      it "prevents overwriting values" do
+        TestRegistry.register!(Integer, 'I')
+        _(-> { TestRegistry.register!(Float, 'I') }).must_raise Flows::Registry::IdentifierTaken
+      end
+
+      it "encodes and decodes values" do
+        TestRegistry.register!(Integer, 'I')
+        _(TestRegistry.encode(Integer)).must_equal 'I'
+      end
+
+      it "raises an exception when unknown key is requested" do
+        _(-> { TestRegistry.encode(Float) }).must_raise Flows::Registry::UnknownIdentifier
+        _(-> { TestRegistry.decode('F') }).must_raise Flows::Registry::UnknownIdentifier
+      end
+    end
+  end
+end


### PR DESCRIPTION
This new format is roughly 10 times more efficient than what we had previously.

### Old format
```json
{
  "class": "Dynflow::Flows::Concurrence",
  "flows": [
    {
      "class": "Dynflow::Flows::Atom",
      "step_id": 3
    },
    {
      "class": "Dynflow::Flows::Sequence",
      "flows": [
        {
          "class": "Dynflow::Flows::Atom",
          "step_id": 4
        },
        {
          "class": "Dynflow::Flows::Atom",
          "step_id": 7
        }
      ]
    },
    {
      "class": "Dynflow::Flows::Atom",
      "step_id": 10
    }
  ]
}
```

### New format
```json
["C",  3,
       ["S", 4, 7],
       10]
```

Note: both examples were reformatted for readability, in the db they are just `MultiJson.dump`ed