### PR TITLE
Make sure sidekiq workers increase their db pool size

### DIFF
--- a/lib/dynflow/rails.rb
+++ b/lib/dynflow/rails.rb
@@ -38,8 +38,8 @@ module Dynflow
       init_world.tap do |world|
         @world = world
         config.run_on_init_hooks(false, world)
+        config.increase_db_pool_size(world) if config.increase_db_pool_size?
         unless config.remote?
-          config.increase_db_pool_size(world)
           config.run_on_init_hooks(true, world)
           # leave this just for long-running executors
           unless config.rake_task_with_executor?

--- a/lib/dynflow/rails.rb
+++ b/lib/dynflow/rails.rb
@@ -38,7 +38,7 @@ module Dynflow
       init_world.tap do |world|
         @world = world
         config.run_on_init_hooks(false, world)
-        config.increase_db_pool_size(world) if config.increase_db_pool_size?
+        config.increase_db_pool_size(world)
         unless config.remote?
           config.run_on_init_hooks(true, world)
           # leave this just for long-running executors

--- a/lib/dynflow/rails/configuration.rb
+++ b/lib/dynflow/rails/configuration.rb
@@ -96,7 +96,11 @@ module Dynflow
       end
 
       def increase_db_pool_size?
-        !::Rails.env.test? && !remote?
+        !::Rails.env.test? && (!remote? || sidekiq_worker?)
+      end
+
+      def sidekiq_worker?
+        defined?(::Sidekiq) && ::Sidekiq.options[:queues].any?
       end
 
       def calculate_db_pool_size(world)


### PR DESCRIPTION
Historically dynflow distinguished between executors (those who perform work)
and clients (those who produce work). Executors increased their db pool size so
that every thread of the executor could get its own connection. Clients didn't
do this, because they didn't really spawn their own thread so whatever
configuration was set was considered correct.

When we introduced Sidekiq we ended up in a slightly odd situation where only
orchestrators were considered executors and other Sidekiq workers were treated
as clients. This also meant, the clients didn't increase their db pool size and
if pressed heavily enough, they could deplete the pool. This change makes other
non-orchestrator workers increase size of their db pools.

To verify pool size is increased, have an action print `ActiveRecord::Base.connection_pool.size` from its `#run`. Alternatively with this patch[1] I was drain all the available connections from the pool.

[1] - https://github.com/Dynflow/dynflow/commit/0a0e566286c9b06b11bc3ad974fe23c08267bab0