### PR TITLE
Do not try to change plan's state if it is in it already

### DIFF
--- a/lib/dynflow/world/invalidation.rb
+++ b/lib/dynflow/world/invalidation.rb
@@ -43,7 +43,7 @@ module Dynflow
                   else
                     :stopped
                   end
-          plan.update_state(state)
+          plan.update_state(state) if plan.state != state
 
           coordinator.release(planning_lock)
           execute(plan.id) if plan.state == :planned


### PR DESCRIPTION
This should prevent errors like invalid transition stopped >> stopped during
world invalidation.