### PR TITLE
Dispatch delayed plan planning through connector 

### DIFF
--- a/lib/dynflow/delayed_executors/abstract_core.rb
+++ b/lib/dynflow/delayed_executors/abstract_core.rb
@@ -46,24 +46,21 @@ module Dynflow
 
       def process(delayed_plans, check_time)
         processed_plan_uuids = []
+        dispatched_plan_uuids = []
+        planning_locks = world.coordinator.find_records(class: Coordinator::PlanningLock.name)
         delayed_plans.each do |plan|
-          next if plan.frozen
+          next if plan.frozen || locked_for_planning?(planning_locks, plan)
           fix_plan_state(plan)
           with_error_handling do
             if plan.execution_plan.state != :scheduled
               # in case the previous process was terminated after running the plan, but before deleting the delayed plan record.
               @logger.info("Execution plan #{plan.execution_plan_uuid} is expected to be in 'scheduled' state, was '#{plan.execution_plan.state}', skipping")
-            elsif !plan.start_before.nil? && plan.start_before < check_time
-              @logger.debug "Failing plan #{plan.execution_plan_uuid}"
-              plan.timeout
+              processed_plan_uuids << plan.execution_plan_uuid
             else
               @logger.debug "Executing plan #{plan.execution_plan_uuid}"
-              Executors.run_user_code do
-                plan.plan
-                plan.execute
-              end
+              world.plan_request(plan.execution_plan_uuid)
+              dispatched_plan_uuids << plan.execution_plan_uuid
             end
-            processed_plan_uuids << plan.execution_plan_uuid
           end
         end
         world.persistence.delete_delayed_plans(:execution_plan_uuid => processed_plan_uuids) unless processed_plan_uuids.empty?
@@ -72,12 +69,17 @@ module Dynflow
       private
 
       # handle the case, where the process was termintated while planning was in progress before
+      # TODO: Doing execution plan updates in orchestrator is bad
       def fix_plan_state(plan)
         if plan.execution_plan.state == :planning
           @logger.info("Execution plan #{plan.execution_plan_uuid} is expected to be in 'scheduled' state, was '#{plan.execution_plan.state}', auto-fixing")
           plan.execution_plan.set_state(:scheduled, true)
           plan.execution_plan.save
         end
+      end
+
+      def locked_for_planning?(planning_locks, plan)
+        planning_locks.any? { |lock| lock.execution_plan_id == plan.execution_plan_uuid }
       end
     end
   end

--- a/lib/dynflow/dispatcher.rb
+++ b/lib/dynflow/dispatcher.rb
@@ -14,6 +14,10 @@ module Dynflow
         fields! execution_plan_id: String
       end
 
+      Planning = type do
+        fields! execution_plan_id: String
+      end
+
       Ping = type do
         fields! receiver_id: String,
                 use_cache: type { variants TrueClass, FalseClass }
@@ -24,7 +28,7 @@ module Dynflow
                 execution_plan_id: type { variants String, NilClass }
       end
 
-      variants Event, Execution, Ping, Status
+      variants Event, Execution, Ping, Status, Planning
     end
 
     Response = Algebrick.type do

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -134,7 +134,7 @@ module Dynflow
       def dispatch_request(request, client_world_id, request_id)
         ignore_unknown = false
         executor_id = match request,
-                            (on ~Execution do |execution|
+                            (on ~Execution | ~Planning do |execution|
                                AnyExecutor
                              end),
                             (on ~Event do |event|

--- a/lib/dynflow/dispatcher/executor_dispatcher.rb
+++ b/lib/dynflow/dispatcher/executor_dispatcher.rb
@@ -9,12 +9,20 @@ module Dynflow
 
       def handle_request(envelope)
         match(envelope.message,
+              on(Planning) { perform_planning(envelope, envelope.message)},
               on(Execution) { perform_execution(envelope, envelope.message) },
               on(Event)     { perform_event(envelope, envelope.message) },
               on(Status)    { get_execution_status(envelope, envelope.message) })
       end
 
       protected
+
+      def perform_planning(envelope, planning)
+        @world.executor.plan(planning.execution_plan_id)
+        respond(envelope, Accepted)
+      rescue Dynflow::Error => e
+        respond(envelope, Failed[e.message])
+      end
 
       def perform_execution(envelope, execution)
         allocate_executor(execution.execution_plan_id, envelope.sender_id, envelope.request_id)

--- a/lib/dynflow/executors/abstract/core.rb
+++ b/lib/dynflow/executors/abstract/core.rb
@@ -35,6 +35,15 @@ module Dynflow
           handle_work(@director.handle_event(event))
         end
 
+        def handle_planning(execution_plan_id)
+          if terminating?
+            raise Dynflow::Error,
+                  "cannot accept event: #{event} core is terminating"
+          end
+
+          handle_work(@director.handle_planning(execution_plan_id))
+        end
+
         def plan_events(delayed_events)
           delayed_events.each do |event|
             @world.plan_event(event.execution_plan_id, event.step_id, event.event, event.time, optional: event.optional)

--- a/lib/dynflow/executors/parallel.rb
+++ b/lib/dynflow/executors/parallel.rb
@@ -38,6 +38,10 @@ module Dynflow
         future
       end
 
+      def plan(execution_plan_id)
+        @core.ask([:handle_planning, execution_plan_id])
+      end
+
       def delayed_event(director_event)
         @core.ask([:handle_event, director_event])
         director_event.result

--- a/lib/dynflow/testing.rb
+++ b/lib/dynflow/testing.rb
@@ -19,6 +19,7 @@ module Dynflow
 
     require 'dynflow/testing/mimic'
     require 'dynflow/testing/managed_clock'
+    require 'dynflow/testing/dummy_coordinator'
     require 'dynflow/testing/dummy_world'
     require 'dynflow/testing/dummy_executor'
     require 'dynflow/testing/dummy_execution_plan'

--- a/lib/dynflow/testing/dummy_coordinator.rb
+++ b/lib/dynflow/testing/dummy_coordinator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Dynflow
+  module Testing
+    class DummyCoordinator
+      def find_records(*args)
+        []
+      end
+    end
+  end
+end

--- a/lib/dynflow/testing/dummy_world.rb
+++ b/lib/dynflow/testing/dummy_world.rb
@@ -5,7 +5,7 @@ module Dynflow
       extend Mimic
       mimic! World
 
-      attr_reader :clock, :executor, :middleware
+      attr_reader :clock, :executor, :middleware, :coordinator
       attr_accessor :action
 
       def initialize(_config = nil)
@@ -13,6 +13,7 @@ module Dynflow
         @clock          = ManagedClock.new
         @executor       = DummyExecutor.new(self)
         @middleware     = Middleware::World.new
+        @coordinator    = DummyCoordinator.new
       end
 
       def action_logger

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -200,6 +200,14 @@ module Dynflow
       Scheduled[execution_plan.id]
     end
 
+    def plan_elsewhere(action_class, *args)
+      execution_plan = ExecutionPlan.new(self, nil)
+      execution_plan.delay(nil, action_class, {}, *args)
+      plan_request(execution_plan.id)
+
+      Scheduled[execution_plan.id]
+    end
+
     def plan(action_class, *args)
       plan_with_options(action_class: action_class, args: args)
     end
@@ -225,6 +233,10 @@ module Dynflow
 
     def plan_event(execution_plan_id, step_id, event, time, accepted = Concurrent::Promises.resolvable_future, optional: false)
       publish_request(Dispatcher::Event[execution_plan_id, step_id, event, time, optional], accepted, false)
+    end
+
+    def plan_request(execution_plan_id, done = Concurrent::Promises.resolvable_future)
+      publish_request(Dispatcher::Planning[execution_plan_id], done, false)
     end
 
     def ping(world_id, timeout, done = Concurrent::Promises.resolvable_future)

--- a/test/future_execution_test.rb
+++ b/test/future_execution_test.rb
@@ -29,14 +29,17 @@ module Dynflow
         describe 'abstract executor' do
           let(:abstract_delayed_executor) { DelayedExecutors::AbstractCore.new(world) }
 
-          it 'handles wrong plan state' do
+          it 'handles plan in planning state' do
             delayed_plan.execution_plan.state = :planning
             abstract_delayed_executor.send(:process, [delayed_plan], @start_at)
-            _(delayed_plan.execution_plan.state).must_equal :planned
+            _(delayed_plan.execution_plan.state).must_equal :scheduled
+          end
 
+          it 'handles plan in running state' do
             delayed_plan.execution_plan.set_state(:running, true)
             abstract_delayed_executor.send(:process, [delayed_plan], @start_at)
             _(delayed_plan.execution_plan.state).must_equal :running
+            _(world.persistence.load_delayed_plan(delayed_plan.execution_plan_uuid)).must_be :nil?
           end
         end
 


### PR DESCRIPTION
Before this patch, planning of delayed plans was done by the delayed executor
actor, which runs in the orchestrator process. This had several drawbacks. The
polling interval used by the delayed executor could increase when it was
performing planning, it could have required additional ActiveRecord connection
and it required the entire application environment to be loaded.

With this change, the actual planning is dispatched through connector to the
workers. To prevent planning a plan twice, a flag is set on the delayed plan
record to indicate it is already being handled. Deletion of delayed plan record
is moved to the worker performing the actual planning.

This also allows us to "plan elsewhere", kick off a task but let another process
perform the plan phase without blocking the client with planning.

Addresses #371 