### PR TITLE
fix: invalid constant exception

### DIFF
--- a/lib/dynflow.rb
+++ b/lib/dynflow.rb
@@ -76,7 +76,7 @@ module Dynflow
   if defined? ::ActiveJob
     require 'dynflow/active_job/queue_adapter'
 
-    class Railtie < Rails::Railtie
+    class Railtie < ::Rails::Railtie
       config.before_initialize do
         ::ActiveJob::QueueAdapters.send(
           :include,


### PR DESCRIPTION
- [x] ! invalid constant exception Railties due to invalid context search