### PR TITLE
Allow marking events as optional

### DIFF
--- a/lib/dynflow/action.rb
+++ b/lib/dynflow/action.rb
@@ -93,7 +93,8 @@ module Dynflow
       fields! execution_plan_id: String,
               step_id:           Integer,
               event:             Object,
-              time:              type { variants Time, NilClass }
+              time:              type { variants Time, NilClass },
+              optional:          Algebrick::Types::Boolean
     end
 
     def self.constantize(action_name)
@@ -332,9 +333,9 @@ module Dynflow
 
     # Plan an +event+ to be send to the action defined by +action+, what defaults to be self.
     # if +time+ is not passed, event is sent as soon as possible.
-    def plan_event(event, time = nil, execution_plan_id: self.execution_plan_id, step_id: self.run_step_id)
+    def plan_event(event, time = nil, execution_plan_id: self.execution_plan_id, step_id: self.run_step_id, optional: false)
       time = @world.clock.current_time + time if time.is_a?(Numeric)
-      delayed_events << DelayedEvent[execution_plan_id, step_id, event, time]
+      delayed_events << DelayedEvent[execution_plan_id, step_id, event, time, optional]
     end
 
     def delayed_events

--- a/lib/dynflow/action/suspended.rb
+++ b/lib/dynflow/action/suspended.rb
@@ -9,14 +9,14 @@ module Dynflow
       @step_id           = action.run_step_id
     end
 
-    def plan_event(event, time, sent = Concurrent::Promises.resolvable_future)
-      @world.plan_event(execution_plan_id, step_id, event, time, sent)
+    def plan_event(event, time, sent = Concurrent::Promises.resolvable_future, optional: false)
+      @world.plan_event(execution_plan_id, step_id, event, time, sent, optional: optional)
     end
 
-    def event(event, sent = Concurrent::Promises.resolvable_future)
+    def event(event, sent = Concurrent::Promises.resolvable_future, optional: false)
       # TODO: deprecate 2 levels backtrace (to know it's called from clock or internaly)
       # remove lib/dynflow/clock.rb ClockReference#ping branch condition on removal.
-      plan_event(event, nil, sent)
+      plan_event(event, nil, sent, optional: optional)
     end
 
     def <<(event = nil)

--- a/lib/dynflow/action/timeouts.rb
+++ b/lib/dynflow/action/timeouts.rb
@@ -7,8 +7,8 @@ module Dynflow
       fail("Timeout exceeded.")
     end
 
-    def schedule_timeout(seconds)
-      plan_event(Timeout, seconds)
+    def schedule_timeout(seconds, optional: false)
+      plan_event(Timeout, seconds, optional: optional)
     end
  end
 end

--- a/lib/dynflow/clock.rb
+++ b/lib/dynflow/clock.rb
@@ -114,11 +114,11 @@ module Dynflow
       Time.now
     end
 
-    def ping(who, time, with_what = nil, where = :<<)
+    def ping(who, time, with_what = nil, where = :<<, optional: false)
       Type! time, Time, Numeric
       time  = current_time + time if time.is_a? Numeric
       if who.is_a?(Action::Suspended)
-        who.plan_event(with_what, time)
+        who.plan_event(with_what, time, optional: optional)
       else
         timer = Clock::Timer[who, time, with_what.nil? ? Algebrick::Types::None : Some[Object][with_what], where]
         self.tell([:add_timer, timer])

--- a/lib/dynflow/director.rb
+++ b/lib/dynflow/director.rb
@@ -15,7 +15,8 @@ module Dynflow
               execution_plan_id: String,
               step_id:           Integer,
               event:             Object,
-              result:            Concurrent::Promises::ResolvableFuture
+              result:            Concurrent::Promises::ResolvableFuture,
+              optional:          Algebrick::Types::Boolean
     end
 
     UnprocessableEvent = Class.new(Dynflow::Error)
@@ -163,6 +164,9 @@ module Dynflow
       execution_plan_manager = @execution_plan_managers[event.execution_plan_id]
       if execution_plan_manager
         execution_plan_manager.event(event)
+      elsif event.optional
+        event.result.reject "no manager for #{event.inspect}"
+        []
       else
         raise Dynflow::Error, "no manager for #{event.inspect}"
       end

--- a/lib/dynflow/dispatcher.rb
+++ b/lib/dynflow/dispatcher.rb
@@ -6,7 +6,8 @@ module Dynflow
         fields! execution_plan_id: String,
                 step_id:           Integer,
                 event:             Object,
-                time:              type { variants Time, NilClass }
+                time:              type { variants Time, NilClass },
+                optional:          Algebrick::Types::Boolean
       end
 
       Execution = type do

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -150,8 +150,7 @@ module Dynflow
 
           message = "Could not find an executor for optional #{envelope}, discarding."
           log(Logger::DEBUG, message)
-          respond(envelope, Failed[message])
-          return
+          return respond(envelope, Failed[message])
         end
         connector.send(envelope).value!
       rescue => e

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -137,7 +137,14 @@ module Dynflow
                                AnyExecutor
                              end),
                             (on ~Event do |event|
-                               find_executor(event.execution_plan_id)
+                               id = find_executor(event.execution_plan_id)
+                               if id == Dispatcher::UnknownWorld && event.optional
+                                 message = "Could not find an executor for optional #{envelope}, discarding."
+                                 log(Logger::DEBUG, message)
+                                 respond(Envelope[request_id, client_world_id, id, request], Failed[message])
+                                 return
+                               end
+                               id
                              end),
                             (on Ping.(~any, ~any) | Status.(~any, ~any) do |receiver_id, _|
                                receiver_id

--- a/lib/dynflow/dispatcher/executor_dispatcher.rb
+++ b/lib/dynflow/dispatcher/executor_dispatcher.rb
@@ -52,12 +52,13 @@ module Dynflow
           end
         end
         if event_request.time.nil? || event_request.time < Time.now
-          @world.executor.event(envelope.request_id, event_request.execution_plan_id, event_request.step_id, event_request.event, future)
+          @world.executor.event(envelope.request_id, event_request.execution_plan_id, event_request.step_id, event_request.event, future,
+                                optional: event_request.optional)
         else
           @world.clock.ping(
             @world.executor,
             event_request.time,
-            Director::Event[envelope.request_id, event_request.execution_plan_id, event_request.step_id, event_request.event, Concurrent::Promises.resolvable_future],
+            Director::Event[envelope.request_id, event_request.execution_plan_id, event_request.step_id, event_request.event, Concurrent::Promises.resolvable_future, event_request.optional],
             :delayed_event
           )
           # resolves the future right away - currently we do not wait for the clock ping

--- a/lib/dynflow/dispatcher/executor_dispatcher.rb
+++ b/lib/dynflow/dispatcher/executor_dispatcher.rb
@@ -58,7 +58,8 @@ module Dynflow
           @world.clock.ping(
             @world.executor,
             event_request.time,
-            Director::Event[envelope.request_id, event_request.execution_plan_id, event_request.step_id, event_request.event, Concurrent::Promises.resolvable_future, event_request.optional],
+            Director::Event[envelope.request_id, event_request.execution_plan_id, event_request.step_id, event_request.event, Concurrent::Promises.resolvable_future,
+                            event_request.optional],
             :delayed_event
           )
           # resolves the future right away - currently we do not wait for the clock ping

--- a/lib/dynflow/executors/abstract/core.rb
+++ b/lib/dynflow/executors/abstract/core.rb
@@ -37,7 +37,7 @@ module Dynflow
 
         def plan_events(delayed_events)
           delayed_events.each do |event|
-            @world.plan_event(event.execution_plan_id, event.step_id, event.event, event.time)
+            @world.plan_event(event.execution_plan_id, event.step_id, event.event, event.time, optional: event.optional)
           end
         end
 

--- a/lib/dynflow/executors/parallel.rb
+++ b/lib/dynflow/executors/parallel.rb
@@ -33,8 +33,8 @@ module Dynflow
         raise e
       end
 
-      def event(request_id, execution_plan_id, step_id, event, future = nil)
-        @core.ask([:handle_event, Director::Event[request_id, execution_plan_id, step_id, event, future]])
+      def event(request_id, execution_plan_id, step_id, event, future = nil, optional: false)
+        @core.ask([:handle_event, Director::Event[request_id, execution_plan_id, step_id, event, future, optional]])
         future
       end
 

--- a/lib/dynflow/testing/in_thread_executor.rb
+++ b/lib/dynflow/testing/in_thread_executor.rb
@@ -34,8 +34,8 @@ module Dynflow
         @director.work_finished(work_item)
       end
 
-      def event(execution_plan_id, step_id, event, future = Concurrent::Promises.resolvable_future)
-        event = (Director::Event[SecureRandom.uuid, execution_plan_id, step_id, event, future])
+      def event(execution_plan_id, step_id, event, future = Concurrent::Promises.resolvable_future, optional: false)
+        event = (Director::Event[SecureRandom.uuid, execution_plan_id, step_id, event, future, optional])
         @director.handle_event(event).each do |work_item|
           @work_items << work_item
         end

--- a/lib/dynflow/testing/in_thread_world.rb
+++ b/lib/dynflow/testing/in_thread_world.rb
@@ -58,15 +58,15 @@ module Dynflow
         future.reject e
       end
 
-      def event(execution_plan_id, step_id, event, done = Concurrent::Promises.resolvable_future)
-        @executor.event(execution_plan_id, step_id, event, done)
+      def event(execution_plan_id, step_id, event, done = Concurrent::Promises.resolvable_future, optional: false)
+        @executor.event(execution_plan_id, step_id, event, done, optional: optional)
       end
 
-      def plan_event(execution_plan_id, step_id, event, time, done = Concurrent::Promises.resolvable_future)
+      def plan_event(execution_plan_id, step_id, event, time, done = Concurrent::Promises.resolvable_future, optional: false)
         if time.nil? || time < Time.now
-          event(execution_plan_id, step_id, event, done)
+          event(execution_plan_id, step_id, event, done, optional: optional)
         else
-          clock.ping(executor, time, Director::Event[SecureRandom.uuid, execution_plan_id, step_id, event, done], :delayed_event)
+          clock.ping(executor, time, Director::Event[SecureRandom.uuid, execution_plan_id, step_id, event, done, optional], :delayed_event)
         end
       end
     end

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -219,12 +219,12 @@ module Dynflow
       publish_request(Dispatcher::Execution[execution_plan_id], done, true)
     end
 
-    def event(execution_plan_id, step_id, event, done = Concurrent::Promises.resolvable_future)
-      publish_request(Dispatcher::Event[execution_plan_id, step_id, event], done, false)
+    def event(execution_plan_id, step_id, event, done = Concurrent::Promises.resolvable_future, optional: false)
+      publish_request(Dispatcher::Event[execution_plan_id, step_id, event, nil, optional], done, false)
     end
 
-    def plan_event(execution_plan_id, step_id, event, time, accepted = Concurrent::Promises.resolvable_future)
-      publish_request(Dispatcher::Event[execution_plan_id, step_id, event, time], accepted, false)
+    def plan_event(execution_plan_id, step_id, event, time, accepted = Concurrent::Promises.resolvable_future, optional: false)
+      publish_request(Dispatcher::Event[execution_plan_id, step_id, event, time, optional], accepted, false)
     end
 
     def ping(world_id, timeout, done = Concurrent::Promises.resolvable_future)

--- a/test/dispatcher_test.rb
+++ b/test/dispatcher_test.rb
@@ -49,6 +49,12 @@ module Dynflow
               plan = result.finished.value
               assert_equal('finish', plan.actions.first.output[:event])
             end
+
+            it 'does not error on dispatching an optional event' do
+              request = client_world.event('123', 1, nil, optional: true)
+              request.wait(20)
+              assert_match /Could not find an executor for optional .*, discarding/, request.reason.message
+            end
           end
         end
       end


### PR DESCRIPTION
Optional events do not raise an exception if they cannot be delivered.