### PR TITLE
Add support for chunked outputs

### DIFF
--- a/examples/chunked_output_benchmark.rb
+++ b/examples/chunked_output_benchmark.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'example_helper'
+require 'benchmark'
+
+WORDS = File.readlines('/usr/share/dict/words').map(&:chomp).freeze
+COUNT = WORDS.count
+
+module Common
+  def main_loop
+    if output[:current] < input[:limit]
+      consumed = yield
+      output[:current] += consumed
+      plan_event(nil)
+      suspend
+    end
+  end
+
+  def batch
+    WORDS.drop(output[:current]).take(input[:chunk])
+  end
+end
+
+class Regular < ::Dynflow::Action
+  include Common
+
+  def run(event = nil)
+    output[:current] ||= 0
+    output[:words] ||= []
+
+    main_loop do
+      words = batch
+      output[:words] << words
+      words.count
+    end
+  end
+end
+
+class Chunked < ::Dynflow::Action
+  include Common
+
+  def run(event = nil)
+    output[:current] ||= 0
+
+    main_loop do
+      words = batch
+      output_chunk(words)
+      words.count
+    end
+  end
+end
+
+if $0 == __FILE__
+  ExampleHelper.world.action_logger.level = 4
+  ExampleHelper.world.logger.level = 4
+
+  Benchmark.bm do |bm|
+    bm.report('regular    1000 by    100') { ExampleHelper.world.trigger(Regular, limit: 1000, chunk: 100).finished.wait }
+    bm.report('chunked    1000 by    100') { ExampleHelper.world.trigger(Chunked, limit: 1000, chunk: 100).finished.wait }
+
+    bm.report('regular  10_000 by    100') { ExampleHelper.world.trigger(Regular, limit: 10_000, chunk: 100).finished.wait }
+    bm.report('chunked  10_000 by    100') { ExampleHelper.world.trigger(Chunked, limit: 10_000, chunk: 100).finished.wait }
+
+    bm.report('regular  10_000 by   1000') { ExampleHelper.world.trigger(Regular, limit: 10_000, chunk: 1000).finished.wait }
+    bm.report('chunked  10_000 by   1000') { ExampleHelper.world.trigger(Chunked, limit: 10_000, chunk: 1000).finished.wait }
+
+    bm.report('regular 100_000 by    100') { ExampleHelper.world.trigger(Regular, limit: 100_000, chunk: 100).finished.wait }
+    bm.report('chunked 100_000 by    100') { ExampleHelper.world.trigger(Chunked, limit: 100_000, chunk: 100).finished.wait }
+
+    bm.report('regular 100_000 by   1000') { ExampleHelper.world.trigger(Regular, limit: 100_000, chunk: 1000).finished.wait }
+    bm.report('chunked 100_000 by   1000') { ExampleHelper.world.trigger(Chunked, limit: 100_000, chunk: 1000).finished.wait }
+
+    bm.report('regular 100_000 by 10_000') { ExampleHelper.world.trigger(Regular, limit: 100_000, chunk: 10_000).finished.wait }
+    bm.report('chunked 100_000 by 10_000') { ExampleHelper.world.trigger(Chunked, limit: 100_000, chunk: 10_000).finished.wait }
+  end
+end

--- a/lib/dynflow/execution_plan/steps/abstract_flow_step.rb
+++ b/lib/dynflow/execution_plan/steps/abstract_flow_step.rb
@@ -31,6 +31,7 @@ module Dynflow
         action = persistence.load_action(self)
         yield action
         persistence.save_action(execution_plan_id, action)
+        persistence.save_output_chunks(execution_plan_id, action.id, action.pending_output_chunks)
         save
 
         return self

--- a/lib/dynflow/persistence.rb
+++ b/lib/dynflow/persistence.rb
@@ -46,6 +46,16 @@ module Dynflow
       adapter.save_action(execution_plan_id, action.id, action.to_hash)
     end
 
+    def save_output_chunks(execution_plan_id, action_id, chunks)
+      return if chunks.empty?
+
+      adapter.save_output_chunks(execution_plan_id, action_id, chunks)
+    end
+
+    def load_output_chunks(execution_plan_id, action_id)
+      adapter.load_output_chunks(execution_plan_id, action_id)
+    end
+
     def find_execution_plans(options)
       adapter.find_execution_plans(options).map do |execution_plan_hash|
         ExecutionPlan.new_from_hash(execution_plan_hash, @world)

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -299,10 +299,15 @@ module Dynflow
 
       def prepare_record(table_name, value, base = {}, with_data = true)
         record = base.dup
-        if with_data && table(table_name).columns.include?(:data)
+        has_data_column = table(table_name).columns.include?(:data)
+        if with_data && has_data_column
           record[:data] = dump_data(value)
         else
-          record.delete(:data)
+          if has_data_column
+            record[:data] = nil
+          else
+            record.delete(:data)
+          end
           record.merge! serialize_columns(table_name, value)
         end
 

--- a/lib/dynflow/persistence_adapters/sequel_migrations/021_create_output_chunks.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/021_create_output_chunks.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+Sequel.migration do
+  up do
+    create_table(:dynflow_output_chunks) do
+      primary_key :id
+
+      foreign_key :execution_plan_uuid, :dynflow_execution_plans, type: String, size: 36, fixed: true, null: false
+      index :execution_plan_uuid
+
+      column :action_id, Integer, null: false
+      foreign_key [:execution_plan_uuid, :action_id], :dynflow_actions,
+                  name: :dynflow_steps_execution_plan_uuid_fkey1
+      index [:execution_plan_uuid, :action_id]
+
+      column :chunk, String, text: true
+      column :kind, String
+      column :timestamp, Time, null: false
+    end
+  end
+
+  down do
+    drop_table(:dynflow_output_chunks)
+  end
+end

--- a/lib/dynflow/persistence_adapters/sequel_migrations/021_create_output_chunks.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/021_create_output_chunks.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 Sequel.migration do
   up do
+    type = database_type
     create_table(:dynflow_output_chunks) do
       primary_key :id
 
-      foreign_key :execution_plan_uuid, :dynflow_execution_plans, type: String, size: 36, fixed: true, null: false
+      column_properties = if type.to_s.include?('postgres')
+                            {type: :uuid}
+                          else
+                            {type: String, size: 36, fixed: true, null: false}
+                          end
+      foreign_key :execution_plan_uuid, :dynflow_execution_plans, **column_properties
       index :execution_plan_uuid
 
       column :action_id, Integer, null: false

--- a/web/views/flow_step.erb
+++ b/web/views/flow_step.erb
@@ -31,6 +31,7 @@
   <% end %>
   <%= show_action_data("Input:", action.input) %>
   <%= show_action_data("Output:", action.output) %>
+  <%= show_action_data("Chunked output:", action.stored_output_chunks) %>
   <% if step.error %>
     <p>
       <b>Error:</b>


### PR DESCRIPTION
The benchmark reads a list of words and then stores first `$count` words as the action's output, grouping them into groups of `$group` words.

```
bundle exec ruby examples/chunked_output_benchmark.rb                                                                                                                                                                     
World 9c3f42c8-e828-471e-8ded-a9fa9f9378e5 started...
                           user       system     total    real
regular    1000 by    100  0.052024   0.006064   0.058088 (  0.049565)
chunked    1000 by    100  0.041618   0.007773   0.049391 (  0.041637)
regular  10_000 by    100  1.085945   0.070478   1.156423 (  1.097117)
chunked  10_000 by    100  0.481077   0.030642   0.511719 (  0.458789)
regular  10_000 by   1000  0.117079   0.001061   0.118140 (  0.113168)
chunked  10_000 by   1000  0.045330   0.004583   0.049913 (  0.042220)
regular 100_000 by    100 70.071629   0.730572  70.802201 ( 70.252973)
chunked 100_000 by    100  8.764937   0.599450   9.364387 (  8.613024)
regular 100_000 by   1000  6.425341   0.028132   6.453473 (  6.389819)
chunked 100_000 by   1000  0.470149   0.021370   0.491519 (  0.423788)
regular 100_000 by 10_000  0.760500   0.001779   0.762279 (  0.754986)
chunked 100_000 by 10_000  0.067514   0.005190   0.072704 (  0.063342)
```

Looking at the `chunked` lines we can see the time grows almost linearly with `$count/$group`, but for the regular output it grows much faster.