### PR TITLE
Fix odd behavior on sqlite 3.7.17

### DIFF
--- a/lib/dynflow/persistence_adapters/sequel_migrations/023_sqlite_workarounds.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/023_sqlite_workarounds.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+tables = [:dynflow_actions, :dynflow_delayed_plans, :dynflow_steps, :dynflow_output_chunks]
+Sequel.migration do
+  up do
+    if database_type == :sqlite && Gem::Version.new(SQLite3::SQLITE_VERSION) <= Gem::Version.new('3.7.17')
+      tables.each do |table|
+        alter_table(table) { drop_foreign_key [:execution_plan_uuid] }
+      end
+    end
+  end
+
+  down do
+    if database_type == :sqlite && Gem::Version.new(SQLite3::SQLITE_VERSION) <= Gem::Version.new('3.7.17')
+      tables.each do |table|
+        alter_table(table) { add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Older sqlite raise foreign key constraint errors even though the data is valid.
The same code works with newer sqlite so I guess it is a bug in sqlite which was
fixed in the meantime.