### PR TITLE
Use JSON directly in json to msgpack migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ end
 
 group :rails do
   gem 'daemons'
-  gem 'rails', '>= 4.2.9'
+  gem 'rails', '>= 4.2.9', '< 7'
   gem 'logging'
 end
 

--- a/lib/dynflow/persistence_adapters/sequel_migrations/022_store_flows_as_msgpack.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/022_store_flows_as_msgpack.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'multi_json'
+require 'json'
 require 'msgpack'
 
 def table_pkeys(table)
@@ -74,7 +74,7 @@ Sequel.migration do
       new_columns = columns.map { |c| "#{c}_blob" }
 
       migrate_table table, columns, new_columns, File do |data|
-        ::Sequel.blob(MessagePack.pack(MultiJson.load(data)))
+        ::Sequel.blob(MessagePack.pack(JSON.parse(data)))
       end
     end
   end
@@ -83,7 +83,7 @@ Sequel.migration do
     TABLES.each do |table, columns|
       new_columns = columns.map { |c| c + '_text' }
       migrate_table table, columns, new_columns, String do |data|
-        MultiJson.dump(MessagePack.unpack(data))
+        JSON.dump(MessagePack.unpack(data))
       end
     end
   end


### PR DESCRIPTION
MultiJson provides a common interface over several JSON parsers. Sadly some of
the parsers have subtle differences.

```ruby
require 'json'
require 'oj'

example = '{"key": 1637704901.3995261}'
Oj.load(example)['key'].class # => BigDecimal
JSON.parse(example)['key'].class # => Float
```