### PR TITLE
Log errors logged during hook runs with error loglevel

### DIFF
--- a/lib/dynflow/execution_plan/hooks.rb
+++ b/lib/dynflow/execution_plan/hooks.rb
@@ -69,7 +69,7 @@ module Dynflow
                 action.send(hook, execution_plan)
               rescue => e
                 execution_plan.logger.error "Failed to run hook '#{hook}' for action '#{action.class}'"
-                execution_plan.logger.debug e
+                execution_plan.logger.error e
               end
             end
           end


### PR DESCRIPTION
Before
```
[2022-01-27 17:34:40.019 #854015] ERROR -- dynflow: Failed to run hook 'halt' for action 'SingletonExampleA'
```

After
```
[2022-01-27 17:34:07.272 #853880] ERROR -- dynflow: Failed to run hook 'halt' for action 'SingletonExampleA'                                                                                                                                                                          
[2022-01-27 17:34:07.272 #853880] ERROR -- dynflow: wrong number of arguments (given 1, expected 0) (ArgumentError)                                                                                                                                                                   
examples/singletons.rb:29:in `halt'                                                                                                                                                                                                                                                   
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan/hooks.rb:69:in `block (2 levels) in run'                                                                                                                                                                                
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan/hooks.rb:67:in `each'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan/hooks.rb:67:in `block in run'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/executors.rb:18:in `run_user_code'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan/hooks.rb:66:in `run'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan.rb:161:in `block (2 levels) in run_hooks'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware/stack.rb:27:in `pass'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware.rb:19:in `pass'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware.rb:56:in `hook'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware/stack.rb:23:in `call'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware/stack.rb:27:in `pass'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware.rb:19:in `pass'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware.rb:56:in `hook'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware/stack.rb:23:in `call'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware/stack.rb:27:in `pass'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware.rb:19:in `pass'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware.rb:56:in `hook'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware/stack.rb:23:in `call'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/middleware/world.rb:31:in `execute'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan.rb:160:in `block in run_hooks'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan.rb:159:in `each'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan.rb:159:in `run_hooks'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan.rb:148:in `block in update_state'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan.rb:148:in `each'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan.rb:148:in `update_state'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/execution_plan.rb:303:in `plan'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/world.rb:219:in `block (2 levels) in plan_with_options'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/coordinator.rb:326:in `acquire'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/world.rb:217:in `block in plan_with_options'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/world.rb:216:in `tap'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/world.rb:216:in `plan_with_options'
/home/aruzicka/work/redhat/dynflow/lib/dynflow/world.rb:212:in `plan' 
/home/aruzicka/work/redhat/dynflow/lib/dynflow/world.rb:180:in `trigger'
examples/singletons.rb:41:in `<main>'
```