### PR TITLE
Add support for halting execution plans

### DIFF
--- a/examples/halt.rb
+++ b/examples/halt.rb
@@ -56,7 +56,7 @@ class Wrapper < Dynflow::Action
   end
 end
 
-if $0 == __FILE__
+if $PROGRAM_NAME == __FILE__
   puts example_description
 
   ExampleHelper.world.action_logger.level = Logger::DEBUG

--- a/examples/halt.rb
+++ b/examples/halt.rb
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'example_helper'
+
+example_description = <<DESC
+
+  Halting example
+  ===================
+
+  This example shows, how halting works in Dynflow. It spawns a single action,
+  which in turn spawns a few evented actions and a single action which occupies
+  the executor for a long time.
+
+  Once the halt event is sent, the execution plan is halted, suspended steps
+  stay suspended forever, running steps stay running until they actually finish
+  the current run and the execution state is flipped over to stopped state.
+
+  You can see the details at #{ExampleHelper::DYNFLOW_URL}
+
+DESC
+
+class EventedCounter < Dynflow::Action
+  def run(event = nil)
+    output[:counter] ||= 0
+    output[:counter] += 1
+    action_logger.info "Iteration #{output[:counter]}"
+
+    if output[:counter] < input[:count]
+      plan_event(:tick, 5)
+      suspend
+    end
+    action_logger.info "Done"
+  end
+end
+
+class Sleeper < Dynflow::Action
+  def run
+    sleep input[:time]
+  end
+end
+
+class Wrapper < Dynflow::Action
+  def plan
+    sequence do
+      concurrence do
+        5.times { |i| plan_action(EventedCounter, :count => i + 1) }
+        plan_action Sleeper, :time => 20
+      end
+      plan_self
+    end
+  end
+
+  def run
+    # Noop
+  end
+end
+
+if $0 == __FILE__
+  puts example_description
+
+  ExampleHelper.world.action_logger.level = Logger::DEBUG
+  ExampleHelper.world
+  t = ExampleHelper.world.trigger(Wrapper)
+  Thread.new do
+    sleep 8
+    ExampleHelper.world.halt(t.id)
+  end
+
+  ExampleHelper.run_web_console
+end

--- a/lib/dynflow/coordinator.rb
+++ b/lib/dynflow/coordinator.rb
@@ -266,6 +266,19 @@ module Dynflow
       end
     end
 
+    class ExecutionInhibitionLock < Lock
+      def initialize(execution_plan_id)
+        super
+        @data[:owner_id] = "execution-plan:#{execution_plan_id}"
+        @data[:execution_plan_id] = execution_plan_id
+        @data[:id] = self.class.lock_id(execution_plan_id)
+      end
+
+      def self.lock_id(execution_plan_id)
+        "execution-plan:#{execution_plan_id}"
+      end
+    end
+
     class ExecutionLock < LockByWorld
       def initialize(world, execution_plan_id, client_world_id, request_id)
         super(world)

--- a/lib/dynflow/director.rb
+++ b/lib/dynflow/director.rb
@@ -335,7 +335,7 @@ module Dynflow
       if @world.coordinator.find_records(filters).any?
         halt_execution(execution_plan_id)
         raise Dynflow::Error,
-              "cannot execute execution_plan_id:#{execution_plan_id} it's execution is inhibited"
+          "cannot execute execution_plan_id:#{execution_plan_id} it's execution is inhibited"
       end
 
       @execution_plan_managers[execution_plan_id] =

--- a/lib/dynflow/director.rb
+++ b/lib/dynflow/director.rb
@@ -246,6 +246,15 @@ module Dynflow
       end
     end
 
+    def halt(event)
+      manager = @execution_plan_managers[event.execution_plan_id]
+      return unless manager
+
+      @logger.warn "Halting execution plan #{event.execution_plan_id}"
+      manager.halt
+      finish_manager manager
+    end
+
     private
 
     def unless_done(manager, work_items)

--- a/lib/dynflow/dispatcher.rb
+++ b/lib/dynflow/dispatcher.rb
@@ -29,7 +29,11 @@ module Dynflow
                 execution_plan_id: type { variants String, NilClass }
       end
 
-      variants Event, Execution, Ping, Status, Planning
+      Halt = type do
+        fields! execution_plan_id: String, optional: Algebrick::Types::Boolean
+      end
+
+      variants Event, Execution, Ping, Status, Planning, Halt
     end
 
     Response = Algebrick.type do

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -137,7 +137,7 @@ module Dynflow
           (on ~Execution | ~Planning do |execution|
              AnyExecutor
            end),
-          (on ~Event do |event|
+          (on ~Event | ~Halt do |event|
              ignore_unknown = event.optional
              find_executor(event.execution_plan_id)
            end),
@@ -236,7 +236,7 @@ module Dynflow
             (on Execution.(execution_plan_id: ~any) do |uuid|
                @world.persistence.load_execution_plan(uuid)
              end),
-            (on Event | Ping do
+            (on Event | Ping | Halt do
                true
              end)
           @tracked_requests.delete(id).success! resolve_to

--- a/lib/dynflow/dispatcher/client_dispatcher.rb
+++ b/lib/dynflow/dispatcher/client_dispatcher.rb
@@ -137,9 +137,13 @@ module Dynflow
           (on ~Execution | ~Planning do |execution|
              AnyExecutor
            end),
-          (on ~Event | ~Halt do |event|
+          (on ~Event do |event|
              ignore_unknown = event.optional
              find_executor(event.execution_plan_id)
+           end),
+          (on ~Halt do |event|
+             executor = find_executor(event.execution_plan_id)
+             executor == Dispatcher::UnknownWorld ? AnyExecutor : executor
            end),
           (on Ping.(~any, ~any) | Status.(~any, ~any) do |receiver_id, _|
              receiver_id

--- a/lib/dynflow/dispatcher/executor_dispatcher.rb
+++ b/lib/dynflow/dispatcher/executor_dispatcher.rb
@@ -13,7 +13,8 @@ module Dynflow
           on(Planning) { perform_planning(envelope, envelope.message) },
           on(Execution) { perform_execution(envelope, envelope.message) },
           on(Event)     { perform_event(envelope, envelope.message) },
-          on(Status)    { get_execution_status(envelope, envelope.message) })
+          on(Status)    { get_execution_status(envelope, envelope.message) },
+          on(Halt)      { halt_execution_plan(envelope, envelope.message) })
       end
 
       protected
@@ -50,6 +51,11 @@ module Dynflow
           @world.coordinator.release(execution_lock)
           respond(envelope, Done)
         end
+      end
+
+      def halt_execution_plan(envelope, execution_plan_id)
+        @world.executor.halt execution_plan_id
+        respond(envelope, Done)
       end
 
       def perform_event(envelope, event_request)

--- a/lib/dynflow/executors/abstract/core.rb
+++ b/lib/dynflow/executors/abstract/core.rb
@@ -66,6 +66,10 @@ module Dynflow
           end
         end
 
+        def halt(execution_plan_id)
+          @director.halt execution_plan_id
+        end
+
         def start_termination(*args)
           logger.info 'shutting down Core ...'
           super

--- a/lib/dynflow/executors/parallel.rb
+++ b/lib/dynflow/executors/parallel.rb
@@ -57,6 +57,10 @@ module Dynflow
         @core.ask!([:execution_status, execution_plan_id])
       end
 
+      def halt(execution_plan_id)
+        @core.tell([:halt, execution_plan_id])
+      end
+
       def initialized
         @core_initialized
       end

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -4,6 +4,7 @@
 require 'dynflow/world/invalidation'
 
 module Dynflow
+  # rubocop:disable Metrics/ClassLength
   class World
     include Algebrick::TypeCheck
     include Algebrick::Matching
@@ -395,4 +396,5 @@ module Dynflow
       return actor
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -252,6 +252,10 @@ module Dynflow
       publish_request(Dispatcher::Status[world_id, execution_plan_id], done, false, timeout)
     end
 
+    def halt(execution_plan_id, accepted = Concurrent::Promises.resolvable_future)
+      publish_request(Dispatcher::Halt[execution_plan_id], accepted, false)
+    end
+
     def publish_request(request, done, wait_for_accepted, timeout = nil)
       accepted = Concurrent::Promises.resolvable_future
       accepted.rescue do |reason|

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -253,6 +253,7 @@ module Dynflow
     end
 
     def halt(execution_plan_id, accepted = Concurrent::Promises.resolvable_future)
+      coordinator.acquire(Coordinator::ExecutionInhibitionLock.new(execution_plan_id))
       publish_request(Dispatcher::Halt[execution_plan_id], accepted, false)
     end
 

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -768,7 +768,7 @@ module Dynflow
         end
 
         it 'halts a scheduled execution plan' do
-          plan = world.delay(Support::DummyExample::Dummy, {start_at: Time.now + 120})
+          plan = world.delay(Support::DummyExample::Dummy, { start_at: Time.now + 120 })
           wait_for do
             plan = world.persistence.load_execution_plan(plan.id)
             plan.state == :scheduled


### PR DESCRIPTION
Up until now, Dynflow only had support for clean cancellation. Upon cancellation
a cancel event was sent to all cancellable suspended and running steps and it
was the action's responsibility to cancel itself. However, there were actions
which just weren't cancellable at all.

This commit adds support for halting execution plans. The actions are completely
unaware of this, on halt dynflow just destroys its internal state about a given
execution plan and turns it to stopped state. It does not remove running steps
from workers as we currently don't have any real means of doing so. Any pending
events will be rejected. In other words, halting an execution plan ensure it
will not run any further.