### PR TITLE
[WIP] Replace deprecated ActiveRecord::Base.configurations[]

### DIFF
--- a/lib/dynflow/rails/configuration.rb
+++ b/lib/dynflow/rails/configuration.rb
@@ -158,7 +158,7 @@ module Dynflow
       protected
 
       def default_sequel_adapter_options(world)
-        db_config            = ::ActiveRecord::Base.configurations[::Rails.env].dup
+        db_config            = ::Rails.application.config.database_configuration[::Rails.env]
         db_config['adapter'] = db_config['adapter'].gsub(/_?makara_?/, '')
         db_config['adapter'] = 'postgres' if db_config['adapter'] == 'postgresql'
         db_config['max_connections'] = calculate_db_pool_size(world) if increase_db_pool_size?


### PR DESCRIPTION
PR for upcoming 6.1 rails upgrade.

Fix for the deprecation warning and the migration error:
```
bundle exec rails db:migrate
2022-02-23T11:44:41 [W|app|] DEPRECATION WARNING: [] is deprecated and will be removed from Rails 6.2 (Use configs_for) (called from dynflow_persistence atforeman61/lib/tasks/dynflow.rake:18)
rails aborted!
NoMethodError: undefined method `gsub' for nil:NilClass
lib/tasks/dynflow.rake:18:in `dynflow_persistence'
lib/tasks/dynflow.rake:23:in `block (2 levels) in <main>'
lib/tasks/dynflow.rake:42:in `block (2 levels) in <main>'
Tasks: TOP => dynflow:migrate
```