### PR TITLE
Fix undefined method wait for nil:NilClass

### DIFF
--- a/lib/dynflow/throttle_limiter.rb
+++ b/lib/dynflow/throttle_limiter.rb
@@ -68,7 +68,7 @@ module Dynflow
         planned_ids.map do |child_id|
           ::Dynflow::World::Triggered[child_id, Concurrent::Promises.resolvable_future].tap do |triggered|
             triggered.future.on_resolution! { self << [:release, parent_id] }
-            execute_triggered(triggered) if @semaphores[parent_id].wait(triggered)
+            execute_triggered(triggered) if @semaphores.key?(parent_id) && @semaphores[parent_id].wait(triggered)
           end
         end + failed
       end


### PR DESCRIPTION
NoMethodError: undefined method `wait' for nil:NilClass
```
/opt/theforeman/tfm/root/usr/share/gems/gems/dynflow-1.4.8/lib/dynflow/throttle_limiter.rb:71:in `block (2 levels) in handle_plans'
/opt/theforeman/tfm/root/usr/share/gems/gems/dynflow-1.4.8/lib/dynflow/throttle_limiter.rb:69:in `tap'
/opt/theforeman/tfm/root/usr/share/gems/gems/dynflow-1.4.8/lib/dynflow/throttle_limiter.rb:69:in `block in handle_plans'
/opt/theforeman/tfm/root/usr/share/gems/gems/dynflow-1.4.8/lib/dynflow/throttle_limiter.rb:68:in `map'
/opt/theforeman/tfm/root/usr/share/gems/gems/dynflow-1.4.8/lib/dynflow/throttle_limiter.rb:68:in `handle_plans'
/opt/theforeman/tfm/root/usr/share/gems/gems/dynflow-1.4.8/lib/dynflow/actor.rb:13:in `on_message'
...