### PR TITLE
Remove suspend folllowing process_timeout

### DIFF
--- a/lib/dynflow/action/polling.rb
+++ b/lib/dynflow/action/polling.rb
@@ -22,7 +22,6 @@ module Dynflow
         poll_external_task_with_rescue
       when Action::Timeouts::Timeout
         process_timeout
-        suspend
       else
         raise "unrecognized event #{event}"
       end


### PR DESCRIPTION
The suspend after timeout can cause a race condition with poll_external_task or resume_external_action if process_timeout doesn't call fail or raise an exception.