### PR TITLE
Fix oddities in delayed planning

### DIFF
--- a/lib/dynflow/director.rb
+++ b/lib/dynflow/director.rb
@@ -167,7 +167,7 @@ module Dynflow
       @logger = world.logger
       @execution_plan_managers = {}
       @rescued_steps = {}
-      @planning_plans = []
+      @planning_plans = Set.new
     end
 
     def current_execution_plan_ids
@@ -175,6 +175,8 @@ module Dynflow
     end
 
     def handle_planning(execution_plan_uuid)
+      return [] if @planning_plans.include? execution_plan_uuid
+
       @planning_plans << execution_plan_uuid
       [PlanningWorkItem.new(execution_plan_uuid, :default, @world.id)]
     end

--- a/lib/dynflow/executors/sidekiq/core.rb
+++ b/lib/dynflow/executors/sidekiq/core.rb
@@ -85,6 +85,9 @@ module Dynflow
           logger.info('Performing validity checks')
           @world.perform_validity_checks
           logger.info('Finished performing validity checks')
+          if @world.delayed_executor && !@world.delayed_executor.started?
+            @world.delayed_executor.start
+          end
           @recovery = false
         end
 

--- a/lib/dynflow/rails/configuration.rb
+++ b/lib/dynflow/rails/configuration.rb
@@ -39,6 +39,7 @@ module Dynflow
         self.eager_load_paths         = []
         self.lazy_initialization      = !::Rails.env.production?
         self.rake_tasks_with_executor = %w(db:migrate db:seed)
+        self.delayed_executor         = nil if sidekiq_worker?
 
         @on_init            = []
         @on_executor_init   = []

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -77,7 +77,7 @@ module Dynflow
       @delayed_executor ||= try_spawn(:delayed_executor, Coordinator::DelayedExecutorLock)
       @execution_plan_cleaner ||= try_spawn(:execution_plan_cleaner, Coordinator::ExecutionPlanCleanerLock)
       update_register
-      @delayed_executor.start if @delayed_executor && !@delayed_executor.started?
+      @delayed_executor.start if auto_validity_check && @delayed_executor && !@delayed_executor.started?
       self.auto_execute if @config.auto_execute
     end
 


### PR DESCRIPTION
Dynflow has a built in subcomponent which runs inside the orchestrator and periodically dispatches delayed execution plans scheduled for the future. Once the delayed plan is properly planned, the delay record (the thing saying "an execution plan $X should be executed at time $T") is destroyed. There are some safeguards in place to ensure a single delayed plan does not get planned multiple times. 

Issue 1:
In sidekiq-based deployments, the delayed plan dispatching subcomponent is started too early, while the rest of the orchestrator is still doing world validity checks. This can lead to a situation where the subcomponent dispatches a single delayed plan multiple times.

Issue 2:
When delayed plans get dispatched multiple times, the safeguards are not handling it properly. The safeguards essentially act as an early return in case the plan in question is already being planned, however, as soon as the early return happens, the delayed record is removed. This breaks planning of the next repetition, which relies on data from it.

This PR addresses ~issue 2~ both issues