### PR TITLE
Access sidekiq config using a non-deprecated way

### DIFF
--- a/examples/remote_executor.rb
+++ b/examples/remote_executor.rb
@@ -168,10 +168,11 @@ elsif defined?(Sidekiq)
   Sidekiq.default_worker_options = { :retry => 0, 'backtrace' => true }
   # assuming the remote executor was required as part of initialization
   # of the ActiveJob worker
-  world = if Sidekiq.options[:queues].include?("dynflow_orchestrator")
+  queues = Sidekiq.configure_server { |c| c.options[:queues] }
+  world = if queues.include?("dynflow_orchestrator")
             RemoteExecutorExample.initialize_sidekiq_orchestrator
-          elsif (Sidekiq.options[:queues] - ['dynflow_orchestrator']).any?
+          elsif (queues - ['dynflow_orchestrator']).any?
             RemoteExecutorExample.initialize_sidekiq_worker
           end
-  Sidekiq.options[:dynflow_world] = world
+  Sidekiq.configure_server { |c| c.options[:dynflow_world] = world }
 end

--- a/lib/dynflow.rb
+++ b/lib/dynflow.rb
@@ -25,7 +25,7 @@ module Dynflow
     # @return [Dynflow::World, nil]
     def process_world
       return @process_world if defined? @process_world
-      @process_world = Sidekiq.options[:dynflow_world]
+      @process_world = Sidekiq.configure_server { |c| c.options[:dynflow_world] }
       raise "process world is not set" unless @process_world
       @process_world
     end

--- a/lib/dynflow/executors/sidekiq/core.rb
+++ b/lib/dynflow/executors/sidekiq/core.rb
@@ -9,7 +9,7 @@ require 'sidekiq-reliable-fetch'
 Sidekiq.configure_server do |config|
   # Use semi-reliable fetch
   # for details see https://gitlab.com/gitlab-org/sidekiq-reliable-fetch/blob/master/README.md
-  config.options[:semi_reliable_fetch] = true
+  config[:semi_reliable_fetch] = true
   Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
 end
 


### PR DESCRIPTION
like
```
WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`
```

#431 