### PR TITLE
Call the on_planning_finished on cancel

### DIFF
--- a/lib/dynflow/action/v2/with_sub_plans.rb
+++ b/lib/dynflow/action/v2/with_sub_plans.rb
@@ -173,6 +173,7 @@ module Dynflow::Action::V2
     def cancel!(force = false)
       # Count the not-yet-planned tasks as cancelled
       output[:cancelled_count] = total_count - output[:planned_count]
+      on_planning_finished if output[:cancelled_count].positive?
       # Pass the cancel event to running sub plans if they can be cancelled
       sub_plans(:state => 'running').each { |sub_plan| sub_plan.cancel(force) if sub_plan.cancellable? }
       suspend


### PR DESCRIPTION
This will only happen if there were any sub-plans which were not planned yet when the cancel event was processed.