### PR TITLE
Fix warnings that started popping up when running on ruby 3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
           ruby-version: 2.7
       - name: Setup
         run: |
-          gem install bundler
+          gem install bundler -v 2.4.22
           bundle install --jobs=3 --retry=3
       - name: Run rubocop
         run: bundle exec rubocop

--- a/lib/dynflow/action/timeouts.rb
+++ b/lib/dynflow/action/timeouts.rb
@@ -10,5 +10,5 @@ module Dynflow
     def schedule_timeout(seconds, optional: false)
       plan_event(Timeout, seconds, optional: optional)
     end
- end
+  end
 end

--- a/lib/dynflow/coordinator.rb
+++ b/lib/dynflow/coordinator.rb
@@ -145,10 +145,6 @@ module Dynflow
         raise "Can't acquire the lock after deserialization" if @from_hash
         Type! owner_id, String
       end
-
-      def to_s
-        "#{self.class.name}: #{id} by #{owner_id}"
-      end
     end
 
     class LockByWorld < Lock

--- a/lib/dynflow/executors/parallel.rb
+++ b/lib/dynflow/executors/parallel.rb
@@ -24,7 +24,7 @@ module Dynflow
         accepted = @core.ask([:handle_execution, execution_plan_id, finished])
         accepted.value! if wait_for_acceptance
         finished
-      rescue Concurrent::Actor::ActorTerminated => error
+      rescue Concurrent::Actor::ActorTerminated
         dynflow_error = Dynflow::Error.new('executor terminated')
         finished.reject dynflow_error unless finished.resolved?
         raise dynflow_error

--- a/lib/dynflow/executors/parallel/pool.rb
+++ b/lib/dynflow/executors/parallel/pool.rb
@@ -16,10 +16,6 @@ module Dynflow
             @jobs.shift
           end
 
-          def queue_size
-            execution_status.values.reduce(0, :+)
-          end
-
           def empty?
             @jobs.empty?
           end

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -99,7 +99,7 @@ module Dynflow
             backup_to_csv(:step, steps, backup_dir, 'steps.csv') if backup_dir
             steps.delete
 
-            output_chunks = table(:output_chunk).where(execution_plan_uuid: uuids).delete
+            table(:output_chunk).where(execution_plan_uuid: uuids).delete
 
             actions = table(:action).where(execution_plan_uuid: uuids)
             backup_to_csv(:action, actions, backup_dir, 'actions.csv') if backup_dir

--- a/lib/dynflow/persistence_adapters/sequel_migrations/018_add_uuid_column.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/018_add_uuid_column.rb
@@ -1,62 +1,67 @@
 # frozen_string_literal: true
-helper = Object.new
-def helper.to_uuid(table_name, column_name)
-  set_column_type(table_name, column_name, :uuid, :using => "#{column_name}::uuid")
-end
-
-def helper.from_uuid(table_name, column_name)
-  set_column_type table_name, column_name, String, primary_key: true, size: 36, fixed: true
-end
-
-def helper.with_foreign_key_recreation(&block)
-  # Drop the foreign key constraints so we can change the column type
-  alter_table :dynflow_actions do
-    drop_foreign_key [:execution_plan_uuid]
-  end
-  alter_table :dynflow_steps do
-    drop_foreign_key [:execution_plan_uuid]
-    drop_foreign_key [:execution_plan_uuid, :action_id], :name => :dynflow_steps_execution_plan_uuid_fkey1
-  end
-  alter_table :dynflow_delayed_plans do
-    drop_foreign_key [:execution_plan_uuid]
+helper = Module.new do
+  def to_uuid(table_name, column_name)
+    set_column_type(table_name, column_name, :uuid, :using => "#{column_name}::uuid")
   end
 
-  block.call
+  def from_uuid(table_name, column_name)
+    set_column_type table_name, column_name, String, primary_key: true, size: 36, fixed: true
+  end
 
-  # Recreat the foreign key constraints as they were before
-  alter_table :dynflow_actions do
-    add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans
-  end
-  alter_table :dynflow_steps do
-    add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans
-    add_foreign_key [:execution_plan_uuid, :action_id], :dynflow_actions,
-                    :name => :dynflow_steps_execution_plan_uuid_fkey1
-  end
-  alter_table :dynflow_delayed_plans do
-    add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans,
-                    :name => :dynflow_scheduled_plans_execution_plan_uuid_fkey
+  def with_foreign_key_recreation(&block)
+    # Drop the foreign key constraints so we can change the column type
+    alter_table :dynflow_actions do
+      drop_foreign_key [:execution_plan_uuid]
+    end
+    alter_table :dynflow_steps do
+      drop_foreign_key [:execution_plan_uuid]
+      drop_foreign_key [:execution_plan_uuid, :action_id], :name => :dynflow_steps_execution_plan_uuid_fkey1
+    end
+    alter_table :dynflow_delayed_plans do
+      drop_foreign_key [:execution_plan_uuid]
+    end
+
+    block.call
+
+    # Recreat the foreign key constraints as they were before
+    alter_table :dynflow_actions do
+      add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans
+    end
+    alter_table :dynflow_steps do
+      add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans
+      add_foreign_key [:execution_plan_uuid, :action_id], :dynflow_actions,
+                      :name => :dynflow_steps_execution_plan_uuid_fkey1
+    end
+    alter_table :dynflow_delayed_plans do
+      add_foreign_key [:execution_plan_uuid], :dynflow_execution_plans,
+                      :name => :dynflow_scheduled_plans_execution_plan_uuid_fkey
+    end
   end
 end
 
 Sequel.migration do
   up do
     if database_type.to_s.include?('postgres')
-      helper.with_foreign_key_recreation do
-        helper.to_uuid :dynflow_execution_plans, :uuid
-        helper.to_uuid :dynflow_actions,         :execution_plan_uuid
-        helper.to_uuid :dynflow_steps,           :execution_plan_uuid
-        helper.to_uuid :dynflow_delayed_plans,   :execution_plan_uuid
+      Sequel::Postgres::Database.include helper
+
+      with_foreign_key_recreation do
+        to_uuid :dynflow_execution_plans, :uuid
+        to_uuid :dynflow_actions,         :execution_plan_uuid
+        to_uuid :dynflow_steps,           :execution_plan_uuid
+        to_uuid :dynflow_delayed_plans,   :execution_plan_uuid
       end
     end
   end
 
   down do
     if database_type.to_s.include?('postgres')
-      helper.with_foreign_key_recreation do
-        helper.from_uuid :dynflow_execution_plans, :uuid
-        helper.from_uuid :dynflow_actions,         :execution_plan_uuid
-        helper.from_uuid :dynflow_steps,           :execution_plan_uuid
-        helper.from_uuid :dynflow_delayed_plans,   :execution_plan_uuid
+      Sequel::Postgres::Database.include helper
+
+      with_foreign_key_recreation do
+        from_uuid :dynflow_execution_plans, :uuid
+        from_uuid :dynflow_actions,         :execution_plan_uuid
+        from_uuid :dynflow_steps,           :execution_plan_uuid
+        from_uuid :dynflow_delayed_plans,   :execution_plan_uuid
       end
     end
   end

--- a/lib/dynflow/persistence_adapters/sequel_migrations/018_add_uuid_column.rb
+++ b/lib/dynflow/persistence_adapters/sequel_migrations/018_add_uuid_column.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
-def to_uuid(table_name, column_name)
+helper = Object.new
+def helper.to_uuid(table_name, column_name)
   set_column_type(table_name, column_name, :uuid, :using => "#{column_name}::uuid")
 end
 
-def from_uuid(table_name, column_name)
+def helper.from_uuid(table_name, column_name)
   set_column_type table_name, column_name, String, primary_key: true, size: 36, fixed: true
 end
 
-def with_foreign_key_recreation(&block)
+def helper.with_foreign_key_recreation(&block)
   # Drop the foreign key constraints so we can change the column type
   alter_table :dynflow_actions do
     drop_foreign_key [:execution_plan_uuid]
@@ -40,22 +41,22 @@ end
 Sequel.migration do
   up do
     if database_type.to_s.include?('postgres')
-      with_foreign_key_recreation do
-        to_uuid :dynflow_execution_plans, :uuid
-        to_uuid :dynflow_actions,         :execution_plan_uuid
-        to_uuid :dynflow_steps,           :execution_plan_uuid
-        to_uuid :dynflow_delayed_plans,   :execution_plan_uuid
+      helper.with_foreign_key_recreation do
+        helper.to_uuid :dynflow_execution_plans, :uuid
+        helper.to_uuid :dynflow_actions,         :execution_plan_uuid
+        helper.to_uuid :dynflow_steps,           :execution_plan_uuid
+        helper.to_uuid :dynflow_delayed_plans,   :execution_plan_uuid
       end
     end
   end
 
   down do
     if database_type.to_s.include?('postgres')
-      with_foreign_key_recreation do
-        from_uuid :dynflow_execution_plans, :uuid
-        from_uuid :dynflow_actions,         :execution_plan_uuid
-        from_uuid :dynflow_steps,           :execution_plan_uuid
-        from_uuid :dynflow_delayed_plans,   :execution_plan_uuid
+      helper.with_foreign_key_recreation do
+        helper.from_uuid :dynflow_execution_plans, :uuid
+        helper.from_uuid :dynflow_actions,         :execution_plan_uuid
+        helper.from_uuid :dynflow_steps,           :execution_plan_uuid
+        helper.from_uuid :dynflow_delayed_plans,   :execution_plan_uuid
       end
     end
   end

--- a/lib/dynflow/telemetry.rb
+++ b/lib/dynflow/telemetry.rb
@@ -18,7 +18,7 @@ module Dynflow
       # Passes the block into the current telemetry adapter's
       # {TelemetryAdapters::Abstract#with_instance} method
       def with_instance(&block)
-        @instance.with_instance &block
+        @instance.with_instance(&block)
       end
 
       def measure(name, tags = {}, &block)

--- a/lib/dynflow/testing/factories.rb
+++ b/lib/dynflow/testing/factories.rb
@@ -39,7 +39,7 @@ module Dynflow
       def plan_action(plan_action, *args, &block)
         Match! plan_action.phase, Action::Plan
 
-        plan_action.execute *args, &block
+        plan_action.execute(*args, &block)
         raise plan_action.error if plan_action.error
         plan_action
       end

--- a/lib/dynflow/testing/mimic.rb
+++ b/lib/dynflow/testing/mimic.rb
@@ -30,9 +30,9 @@ module Dynflow
         end
 
         if self.kind_of? ::Class
-          self.class_eval &define
+          self.class_eval(&define)
         else
-          self.singleton_class.class_eval &define
+          self.singleton_class.class_eval(&define)
         end
 
         self

--- a/lib/dynflow/world.rb
+++ b/lib/dynflow/world.rb
@@ -297,7 +297,7 @@ module Dynflow
       coordinator.acquire(lock_class.new(self)) if lock_class
       object.spawn.wait
       object
-    rescue Coordinator::LockError => e
+    rescue Coordinator::LockError
       nil
     end
 


### PR DESCRIPTION
These were fixed
```
lib/dynflow/coordinator.rb:149: warning: method redefined; discarding old to_s
lib/dynflow/coordinator.rb:133: warning: previous definition of to_s was here
lib/dynflow/persistence_adapters/sequel.rb:102: warning: assigned but unused variable - output_chunks
lib/dynflow/action/timeouts.rb:13: warning: mismatched indentations at 'end' with 'module' at 3
lib/dynflow/executors/parallel.rb:27: warning: assigned but unused variable - error
lib/dynflow/executors/parallel/pool.rb:27: warning: method redefined; discarding old queue_size
lib/dynflow/executors/parallel/pool.rb:19: warning: previous definition of queue_size was here
lib/dynflow/world.rb:300: warning: assigned but unused variable - e
lib/dynflow/telemetry.rb:21: warning: `&' interpreted as argument prefix
lib/dynflow/testing/mimic.rb:33: warning: `&' interpreted as argument prefix
lib/dynflow/testing/mimic.rb:35: warning: `&' interpreted as argument prefix
lib/dynflow/testing/factories.rb:42: warning: `*' interpreted as argument prefix
lib/dynflow/persistence_adapters/sequel_migrations/018_add_uuid_column.rb:2: warning: method redefined; discarding old to_uuid lib/dynflow/persistence_adapters/sequel_migrations/018_add_uuid_column.rb:2: warning: previous definition of to_uuid was here
lib/dynflow/persistence_adapters/sequel_migrations/018_add_uuid_column.rb:6: warning: method redefined; discarding old from_uuid
lib/dynflow/persistence_adapters/sequel_migrations/018_add_uuid_column.rb:6: warning: previous definition of from_uuid was here lib/dynflow/persistence_adapters/sequel_migrations/018_add_uuid_column.rb:10: warning: method redefined; discarding old with_foreign_key_recreation
lib/dynflow/persistence_adapters/sequel_migrations/018_add_uuid_column.rb:10: warning: previous definition of with_foreign_key_recreation was here
```

The following three come from us dynamically generating methods and then overriding some of them
```
lib/dynflow/config.rb:105: warning: method redefined; discarding old validate_executor!
lib/dynflow/config.rb:9: warning: previous definition of validate_executor! was here
lib/dynflow/testing/mimic.rb:15: warning: method redefined; discarding old ===
```

CC @ofedoren I was seeing these when running smart_proxy_dynflow tests with ruby 3