### PR TITLE
Suppress serialization warnings from Sidekiq

### DIFF
--- a/lib/dynflow/executors/sidekiq/core.rb
+++ b/lib/dynflow/executors/sidekiq/core.rb
@@ -13,6 +13,7 @@ Sidekiq.configure_server do |config|
   config[:semi_reliable_fetch] = true
   Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
 end
+::Sidekiq.strict_args!(false)
 
 module Dynflow
   module Executors


### PR DESCRIPTION
There are some changes coming in Sidekiq 7 that will need changes on our side and currently Sidekiq emits lots of warnings about it. We are aware of the issue, but until we resolve it properly, it doesn't make sense to spam all the users' logs with it.