### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/dynflow.rb
+++ b/lib/dynflow.rb
@@ -25,7 +25,7 @@ module Dynflow
     # @return [Dynflow::World, nil]
     def process_world
       return @process_world if defined? @process_world
-      @process_world = Sidekiq.configure_server { |c| c.options[:dynflow_world] }
+      @process_world = Sidekiq.configure_server { |c| c[:dynflow_world] }
       raise "process world is not set" unless @process_world
       @process_world
     end


### PR DESCRIPTION
This fixes the following deprecation warning:
WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`: ["/usr/share/gems/gems/dynflow-1.8.2/lib/dynflow.rb:28:in `block in process_world'", "/usr/share/gems/gems/sidekiq-6.5.12/lib/sidekiq.rb:142:in `configure_server'"]