### PR TITLE
Edit how failed_count and cancelled_count is calculated

### DIFF
--- a/lib/dynflow/persistence.rb
+++ b/lib/dynflow/persistence.rb
@@ -73,6 +73,10 @@ module Dynflow
       adapter.find_execution_plan_counts(options)
     end
 
+    def find_execution_plan_counts_after(timestamp, options)
+      adapter.find_execution_plan_counts_after(timestamp, options)
+    end
+
     def delete_execution_plans(filters, batch_size = 1000, enforce_backup_dir = nil)
       backup_dir = enforce_backup_dir || current_backup_dir
       adapter.delete_execution_plans(filters, batch_size, backup_dir)

--- a/lib/dynflow/persistence_adapters/abstract.rb
+++ b/lib/dynflow/persistence_adapters/abstract.rb
@@ -46,6 +46,10 @@ module Dynflow
         filter(:execution_plan, options[:filters]).count
       end
 
+      def find_execution_plan_counts_after(timestamp, options = {})
+        raise NotImplementedError
+      end
+
       def find_execution_plan_statuses(options)
         raise NotImplementedError
       end

--- a/lib/dynflow/persistence_adapters/sequel.rb
+++ b/lib/dynflow/persistence_adapters/sequel.rb
@@ -78,6 +78,10 @@ module Dynflow
         filter(:execution_plan, table(:execution_plan), options[:filters]).count
       end
 
+      def find_execution_plan_counts_after(timestamp, options = {})
+        filter(:execution_plan, table(:execution_plan), options[:filters]).filter(::Sequel.lit('ended_at >= ?', timestamp)).count
+      end
+
       def find_execution_plan_statuses(options)
         plans = filter(:execution_plan, table(:execution_plan), options[:filters])
                 .select(:uuid, :state, :result)


### PR DESCRIPTION
This PR proposes to mark every sub plan which finishes as not successful
after the parent execution plan receives the cancel directive as
cancelled. This is to be consistent with how a task is evaluated as
cancelled in the foreman project.

This PR has an additional effect which makes the parent execution plan
always finish with warning if at least one sub plan is cancelled as a
response to the `cancel` event. Until now, it could either finish with
success if all subplans either finished with success or were not yet
queued for execution or it could finish with warning if already pending
sub plan was cancelled and finished with the `error` result.  In
summary, this additional change unifies the behavior of a cancelled
execution plan if there is anything left to cancel.