### PR TITLE
Drop optional field from Halt request variant

### DIFF
--- a/lib/dynflow/dispatcher.rb
+++ b/lib/dynflow/dispatcher.rb
@@ -30,7 +30,7 @@ module Dynflow
       end
 
       Halt = type do
-        fields! execution_plan_id: String, optional: Algebrick::Types::Boolean
+        fields! execution_plan_id: String
       end
 
       variants Event, Execution, Ping, Status, Planning, Halt


### PR DESCRIPTION
It is not used anywhere. Previously we were leaving it unset, which was fine in single-process scenarios (such as tests and development environments), but failed in cases where the request took a round trip through the database.